### PR TITLE
Fix HexFiend on 32 bit systems

### DIFF
--- a/English.lproj/MainMenu.xib
+++ b/English.lproj/MainMenu.xib
@@ -1109,7 +1109,7 @@
 									<int key="NSMnemonicLoc">2147483647</int>
 									<reference key="NSOnImage" ref="171599450"/>
 									<reference key="NSMixedImage" ref="491729860"/>
-									<int key="NSTag">2483028224</int>
+									<int key="NSTag">-1811939072</int>
 								</object>
 								<object class="NSMenuItem" id="973582821">
 									<reference key="NSMenu" ref="974353390"/>
@@ -1118,7 +1118,7 @@
 									<int key="NSMnemonicLoc">2147483647</int>
 									<reference key="NSOnImage" ref="171599450"/>
 									<reference key="NSMixedImage" ref="491729860"/>
-									<int key="NSTag">2415919360</int>
+									<int key="NSTag">-1879047936</int>
 								</object>
 								<object class="NSMenuItem" id="801002076">
 									<reference key="NSMenu" ref="974353390"/>


### PR DESCRIPTION
HexFiend crashes on startup on 32 bit systems. This is listed as a known bug.

I am the MacPorts maintainer of HexFiend and have recently received the same bug report at https://trac.macports.org/ticket/35244. I've taken the time to look into this and have found replacing the offending integer values with their signed interpretation fixes this problem on 32 bit systems while not changing the behavior of 64 bit systems.
