### PR TITLE
Reduce compiler warnings by adding appropriate casts.

### DIFF
--- a/English.lproj/DiffComputationBanner.xib
+++ b/English.lproj/DiffComputationBanner.xib
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1060</int>
-		<string key="IBDocument.SystemVersion">11C74</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1938</string>
-		<string key="IBDocument.AppKitVersion">1138.23</string>
-		<string key="IBDocument.HIToolboxVersion">567.00</string>
+		<int key="IBDocument.SystemTarget">1070</int>
+		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1938</string>
+			<string key="NS.object.0">3084</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
-			<string>NSTextField</string>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
 			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
-			<string>NSButtonCell</string>
-			<string>NSButton</string>
-			<string>NSUserDefaultsController</string>
+			<string>NSTextField</string>
 			<string>NSTextFieldCell</string>
+			<string>NSUserDefaultsController</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -54,11 +54,9 @@
 								<int key="NSvFlags">258</int>
 								<string key="NSFrame">{{51, 5}, {393, 14}}</string>
 								<reference key="NSSuperview" ref="878688695"/>
-								<reference key="NSWindow"/>
-								<reference key="NSNextKeyView"/>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSTextFieldCell" key="NSCell" id="677922081">
-									<int key="NSCellFlags">68288064</int>
+									<int key="NSCellFlags">68157504</int>
 									<int key="NSCellFlags2">272761856</int>
 									<string key="NSContents">Computing differences</string>
 									<object class="NSFont" key="NSSupport">
@@ -86,17 +84,17 @@
 										</object>
 									</object>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSButton" id="342010705">
 								<reference key="NSNextResponder" ref="878688695"/>
 								<int key="NSvFlags">-2147483388</int>
 								<string key="NSFrame">{{28, 7}, {11, 11}}</string>
 								<reference key="NSSuperview" ref="878688695"/>
-								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="758443218"/>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSButtonCell" key="NSCell" id="774131558">
-									<int key="NSCellFlags">67239424</int>
+									<int key="NSCellFlags">67108864</int>
 									<int key="NSCellFlags2">134217728</int>
 									<string key="NSContents"/>
 									<object class="NSFont" key="NSSupport">
@@ -105,25 +103,24 @@
 										<int key="NSfFlags">1044</int>
 									</object>
 									<reference key="NSControlView" ref="342010705"/>
-									<int key="NSButtonFlags">-2041298689</int>
+									<int key="NSButtonFlags">-2041298944</int>
 									<int key="NSButtonFlags2">134</int>
 									<string key="NSAlternateContents"/>
 									<string key="NSKeyEquivalent"/>
 									<int key="NSPeriodicDelay">200</int>
 									<int key="NSPeriodicInterval">25</int>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 						</object>
 						<string key="NSFrameSize">{464, 24}</string>
 						<reference key="NSSuperview" ref="1005"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="342010705"/>
 						<string key="NSClassName">StretchableProgressIndicator</string>
 					</object>
 				</object>
 				<string key="NSFrameSize">{464, 24}</string>
 				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="878688695"/>
 				<string key="NSClassName">HFDocumentOperationView</string>
 			</object>
@@ -268,7 +265,7 @@
 					<string>51.IBPluginDependency</string>
 					<string>54.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -303,307 +300,12 @@
 			<nil key="sourceID"/>
 			<int key="maxID">59</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBPartialClassDescription">
-					<string key="className">BaseDataDocument</string>
-					<string key="superclassName">NSDocument</string>
-					<object class="NSMutableDictionary" key="actions">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>decreaseFontSize:</string>
-							<string>deleteBookmark:</string>
-							<string>findNext:</string>
-							<string>findPrevious:</string>
-							<string>increaseFontSize:</string>
-							<string>modifyByteGrouping:</string>
-							<string>moveSelectionByAction:</string>
-							<string>performFindReplaceActionFromSelectedSegment:</string>
-							<string>replace:</string>
-							<string>replaceAll:</string>
-							<string>replaceAndFind:</string>
-							<string>setAntialiasFromMenuItem:</string>
-							<string>setBookmark:</string>
-							<string>setStringEncodingFromMenuItem:</string>
-							<string>showFontPanel:</string>
-							<string>toggleOverwriteMode:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>NSMenuItem</string>
-							<string>id</string>
-							<string>id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>decreaseFontSize:</string>
-							<string>deleteBookmark:</string>
-							<string>findNext:</string>
-							<string>findPrevious:</string>
-							<string>increaseFontSize:</string>
-							<string>modifyByteGrouping:</string>
-							<string>moveSelectionByAction:</string>
-							<string>performFindReplaceActionFromSelectedSegment:</string>
-							<string>replace:</string>
-							<string>replaceAll:</string>
-							<string>replaceAndFind:</string>
-							<string>setAntialiasFromMenuItem:</string>
-							<string>setBookmark:</string>
-							<string>setStringEncodingFromMenuItem:</string>
-							<string>showFontPanel:</string>
-							<string>toggleOverwriteMode:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBActionInfo">
-								<string key="name">decreaseFontSize:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">deleteBookmark:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">findNext:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">findPrevious:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">increaseFontSize:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">modifyByteGrouping:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">moveSelectionByAction:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">performFindReplaceActionFromSelectedSegment:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">replace:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">replaceAll:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">replaceAndFind:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">setAntialiasFromMenuItem:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">setBookmark:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">setStringEncodingFromMenuItem:</string>
-								<string key="candidateClassName">NSMenuItem</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">showFontPanel:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">toggleOverwriteMode:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">containerView</string>
-						<string key="NS.object.0">NSSplitView</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">containerView</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">containerView</string>
-							<string key="candidateClassName">NSSplitView</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/BaseDataDocument.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">HFCancelButton</string>
-					<string key="superclassName">NSButton</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/HFCancelButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">HFDocumentOperationView</string>
-					<string key="superclassName">HFResizingView</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">cancelViewOperation:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">cancelViewOperation:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">cancelViewOperation:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="outlets">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>cancelButton</string>
-							<string>progressIndicator</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>NSButton</string>
-							<string>NSProgressIndicator</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>cancelButton</string>
-							<string>progressIndicator</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBToOneOutletInfo">
-								<string key="name">cancelButton</string>
-								<string key="candidateClassName">NSButton</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">progressIndicator</string>
-								<string key="candidateClassName">NSProgressIndicator</string>
-							</object>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/HFDocumentOperationView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">HFResizingView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/HFResizingView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSDocument</string>
-					<object class="NSMutableDictionary" key="actions">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>printDocument:</string>
-							<string>revertDocumentToSaved:</string>
-							<string>runPageLayout:</string>
-							<string>saveDocument:</string>
-							<string>saveDocumentAs:</string>
-							<string>saveDocumentTo:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>printDocument:</string>
-							<string>revertDocumentToSaved:</string>
-							<string>runPageLayout:</string>
-							<string>saveDocument:</string>
-							<string>saveDocumentAs:</string>
-							<string>saveDocumentTo:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBActionInfo">
-								<string key="name">printDocument:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">revertDocumentToSaved:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">runPageLayout:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">saveDocument:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">saveDocumentAs:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">saveDocumentTo:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NSDocument.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">StretchableProgressIndicator</string>
-					<string key="superclassName">NSProgressIndicator</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/StretchableProgressIndicator.h</string>
-					</object>
-				</object>
-			</object>
-		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes"/>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1060" key="NS.object.0"/>
+			<real value="1070" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>

--- a/English.lproj/FindReplaceBanner.xib
+++ b/English.lproj/FindReplaceBanner.xib
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1050</int>
-		<string key="IBDocument.SystemVersion">11C74</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1938</string>
-		<string key="IBDocument.AppKitVersion">1138.23</string>
-		<string key="IBDocument.HIToolboxVersion">567.00</string>
+		<int key="IBDocument.SystemTarget">1070</int>
+		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1938</string>
+			<string key="NS.object.0">3084</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
 			<string>NSCustomObject</string>
+			<string>NSCustomView</string>
+			<string>NSSegmentedCell</string>
+			<string>NSSegmentedControl</string>
 			<string>NSTextField</string>
 			<string>NSTextFieldCell</string>
-			<string>NSSegmentedCell</string>
-			<string>NSCustomView</string>
-			<string>NSButtonCell</string>
-			<string>NSButton</string>
 			<string>NSUserDefaultsController</string>
-			<string>NSSegmentedControl</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -51,10 +51,10 @@
 						<int key="NSvFlags">289</int>
 						<string key="NSFrame">{{100, 5}, {339, 18}}</string>
 						<reference key="NSSuperview" ref="1005"/>
-						<reference key="NSNextKeyView"/>
+						<reference key="NSWindow"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSSegmentedCell" key="NSCell" id="151734930">
-							<int key="NSCellFlags">67239424</int>
+							<int key="NSCellFlags">67108864</int>
 							<int key="NSCellFlags2">131072</int>
 							<object class="NSFont" key="NSSupport" id="26">
 								<string key="NSName">LucidaGrande</string>
@@ -90,16 +90,18 @@
 							<int key="NSTrackingMode">2</int>
 							<int key="NSSegmentStyle">3</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="168651019">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">-2147483348</int>
 						<string key="NSFrame">{{15, 26}, {11, 11}}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="638879442"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="986322513">
-							<int key="NSCellFlags">67239424</int>
+							<int key="NSCellFlags">67108864</int>
 							<int key="NSCellFlags2">134217728</int>
 							<string key="NSContents"/>
 							<object class="NSFont" key="NSSupport">
@@ -108,23 +110,25 @@
 								<int key="NSfFlags">1044</int>
 							</object>
 							<reference key="NSControlView" ref="168651019"/>
-							<int key="NSButtonFlags">139739391</int>
+							<int key="NSButtonFlags">139739136</int>
 							<int key="NSButtonFlags2">134</int>
 							<string key="NSAlternateContents"/>
 							<string key="NSKeyEquivalent"/>
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSSegmentedControl" id="457221005">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">268</int>
 						<string key="NSFrame">{{8, 49}, {84, 18}}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="168651019"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSSegmentedCell" key="NSCell" id="401570410">
-							<int key="NSCellFlags">67239424</int>
+							<int key="NSCellFlags">67108864</int>
 							<int key="NSCellFlags2">131072</int>
 							<reference key="NSSupport" ref="26"/>
 							<reference key="NSControlView" ref="457221005"/>
@@ -144,6 +148,7 @@
 							<int key="NSSelectedSegment">1</int>
 							<int key="NSSegmentStyle">3</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSCustomView" id="638879442">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -160,10 +165,11 @@
 										<int key="NSvFlags">268</int>
 										<string key="NSFrame">{{17, 3}, {38, 16}}</string>
 										<reference key="NSSuperview" ref="739882413"/>
+										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="18878521"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="568357850">
-											<int key="NSCellFlags">67239488</int>
+											<int key="NSCellFlags">67108928</int>
 											<int key="NSCellFlags2">71304192</int>
 											<string key="NSContents">Find</string>
 											<object class="NSFont" key="NSSupport" id="72911520">
@@ -191,18 +197,21 @@
 												</object>
 											</object>
 										</object>
+										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 									</object>
 									<object class="NSCustomView" id="18878521">
 										<reference key="NSNextResponder" ref="739882413"/>
 										<int key="NSvFlags">274</int>
 										<string key="NSFrame">{{63, 2}, {290, 18}}</string>
 										<reference key="NSSuperview" ref="739882413"/>
+										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="25928326"/>
 										<string key="NSClassName">HFTextField</string>
 									</object>
 								</object>
 								<string key="NSFrame">{{0, 24}, {359, 24}}</string>
 								<reference key="NSSuperview" ref="638879442"/>
+								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="64193229"/>
 								<string key="NSClassName">HFResizingView</string>
 							</object>
@@ -216,10 +225,11 @@
 										<int key="NSvFlags">268</int>
 										<string key="NSFrame">{{5, 5}, {53, 16}}</string>
 										<reference key="NSSuperview" ref="25928326"/>
+										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="1054605105"/>
 										<bool key="NSEnabled">YES</bool>
 										<object class="NSTextFieldCell" key="NSCell" id="823614387">
-											<int key="NSCellFlags">67239488</int>
+											<int key="NSCellFlags">67108928</int>
 											<int key="NSCellFlags2">71304192</int>
 											<string key="NSContents">Replace</string>
 											<reference key="NSSupport" ref="72911520"/>
@@ -227,24 +237,28 @@
 											<reference key="NSBackgroundColor" ref="1001794283"/>
 											<reference key="NSTextColor" ref="406380824"/>
 										</object>
+										<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 									</object>
 									<object class="NSCustomView" id="1054605105">
 										<reference key="NSNextResponder" ref="25928326"/>
 										<int key="NSvFlags">274</int>
 										<string key="NSFrame">{{63, 4}, {290, 18}}</string>
 										<reference key="NSSuperview" ref="25928326"/>
+										<reference key="NSWindow"/>
 										<reference key="NSNextKeyView" ref="551564727"/>
 										<string key="NSClassName">HFTextField</string>
 									</object>
 								</object>
 								<string key="NSFrameSize">{359, 24}</string>
 								<reference key="NSSuperview" ref="638879442"/>
+								<reference key="NSWindow"/>
 								<reference key="NSNextKeyView" ref="135703682"/>
 								<string key="NSClassName">HFResizingView</string>
 							</object>
 						</object>
 						<string key="NSFrame">{{89, 25}, {359, 48}}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="739882413"/>
 						<string key="NSClassName">HFResizingView</string>
 					</object>
@@ -253,12 +267,14 @@
 						<int key="NSvFlags">274</int>
 						<string key="NSFrameSize">{448, 73}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="457221005"/>
 						<string key="NSClassName">StretchableProgressIndicator</string>
 					</object>
 				</object>
 				<string key="NSFrameSize">{448, 73}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="121329192"/>
 				<string key="NSClassName">HFFindReplaceOperationView</string>
 			</object>
@@ -554,7 +570,7 @@
 					<string>99.IBPluginDependency</string>
 					<string>99.userInterfaceItemIdentifier</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -601,12 +617,338 @@
 			<nil key="sourceID"/>
 			<int key="maxID">155</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBPartialClassDescription">
+					<string key="className">BaseDataDocument</string>
+					<string key="superclassName">NSDocument</string>
+					<object class="NSMutableDictionary" key="actions">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>decreaseFontSize:</string>
+							<string>deleteBookmark:</string>
+							<string>findNext:</string>
+							<string>findPrevious:</string>
+							<string>increaseFontSize:</string>
+							<string>modifyByteGrouping:</string>
+							<string>moveSelectionByAction:</string>
+							<string>performFindReplaceActionFromSelectedSegment:</string>
+							<string>replace:</string>
+							<string>replaceAll:</string>
+							<string>replaceAndFind:</string>
+							<string>setAntialiasFromMenuItem:</string>
+							<string>setBookmark:</string>
+							<string>setInsertMode:</string>
+							<string>setOverwriteMode:</string>
+							<string>setReadOnlyMode:</string>
+							<string>setStringEncodingFromMenuItem:</string>
+							<string>showFontPanel:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>NSMenuItem</string>
+							<string>id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>decreaseFontSize:</string>
+							<string>deleteBookmark:</string>
+							<string>findNext:</string>
+							<string>findPrevious:</string>
+							<string>increaseFontSize:</string>
+							<string>modifyByteGrouping:</string>
+							<string>moveSelectionByAction:</string>
+							<string>performFindReplaceActionFromSelectedSegment:</string>
+							<string>replace:</string>
+							<string>replaceAll:</string>
+							<string>replaceAndFind:</string>
+							<string>setAntialiasFromMenuItem:</string>
+							<string>setBookmark:</string>
+							<string>setInsertMode:</string>
+							<string>setOverwriteMode:</string>
+							<string>setReadOnlyMode:</string>
+							<string>setStringEncodingFromMenuItem:</string>
+							<string>showFontPanel:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBActionInfo">
+								<string key="name">decreaseFontSize:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">deleteBookmark:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">findNext:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">findPrevious:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">increaseFontSize:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">modifyByteGrouping:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">moveSelectionByAction:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">performFindReplaceActionFromSelectedSegment:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replace:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replaceAll:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replaceAndFind:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setAntialiasFromMenuItem:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setBookmark:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setInsertMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setOverwriteMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setReadOnlyMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setStringEncodingFromMenuItem:</string>
+								<string key="candidateClassName">NSMenuItem</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">showFontPanel:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">containerView</string>
+						<string key="NS.object.0">NSSplitView</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">containerView</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">containerView</string>
+							<string key="candidateClassName">NSSplitView</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/BaseDataDocument.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFCancelButton</string>
+					<string key="superclassName">NSButton</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFCancelButton.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFDocumentOperationView</string>
+					<string key="superclassName">HFResizingView</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">cancelViewOperation:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">cancelViewOperation:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">cancelViewOperation:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>cancelButton</string>
+							<string>progressIndicator</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>NSButton</string>
+							<string>NSProgressIndicator</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>cancelButton</string>
+							<string>progressIndicator</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">cancelButton</string>
+								<string key="candidateClassName">NSButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">progressIndicator</string>
+								<string key="candidateClassName">NSProgressIndicator</string>
+							</object>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFDocumentOperationView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFFindReplaceOperationView</string>
+					<string key="superclassName">HFDocumentOperationView</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">modifyFieldTypeFromControl:</string>
+						<string key="NS.object.0">NSSegmentedControl</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">modifyFieldTypeFromControl:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">modifyFieldTypeFromControl:</string>
+							<string key="candidateClassName">NSSegmentedControl</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>document</string>
+							<string>fieldTypeControl</string>
+							<string>findField</string>
+							<string>replaceField</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>BaseDataDocument</string>
+							<string>NSSegmentedControl</string>
+							<string>HFTextField</string>
+							<string>HFTextField</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>document</string>
+							<string>fieldTypeControl</string>
+							<string>findField</string>
+							<string>replaceField</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">document</string>
+								<string key="candidateClassName">BaseDataDocument</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">fieldTypeControl</string>
+								<string key="candidateClassName">NSSegmentedControl</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">findField</string>
+								<string key="candidateClassName">HFTextField</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">replaceField</string>
+								<string key="candidateClassName">HFTextField</string>
+							</object>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFFindReplaceOperationView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFResizingView</string>
+					<string key="superclassName">NSView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFResizingView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFTextField</string>
+					<string key="superclassName">NSControl</string>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">target</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">target</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">target</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFTextField.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">StretchableProgressIndicator</string>
+					<string key="superclassName">NSProgressIndicator</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/StretchableProgressIndicator.h</string>
+					</object>
+				</object>
+			</object>
+		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1050" key="NS.object.0"/>
+			<real value="1070" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>

--- a/English.lproj/JumpToOffsetBanner.xib
+++ b/English.lproj/JumpToOffsetBanner.xib
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1060</int>
-		<string key="IBDocument.SystemVersion">11C74</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1938</string>
-		<string key="IBDocument.AppKitVersion">1138.23</string>
-		<string key="IBDocument.HIToolboxVersion">567.00</string>
+		<int key="IBDocument.SystemTarget">1070</int>
+		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1938</string>
+			<string key="NS.object.0">3084</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
+			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSTextField</string>
 			<string>NSTextFieldCell</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSButton</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -48,10 +48,11 @@
 						<int key="NSvFlags">266</int>
 						<string key="NSFrame">{{130, 9}, {227, 19}}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="142255690"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="1035097676">
-							<int key="NSCellFlags">-1804468671</int>
+							<int key="NSCellFlags">-1804599231</int>
 							<int key="NSCellFlags2">268567552</int>
 							<string key="NSContents"/>
 							<object class="NSFont" key="NSSupport" id="26">
@@ -80,16 +81,18 @@
 								</object>
 							</object>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="468221191">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">268</int>
 						<string key="NSFrame">{{25, 11}, {100, 14}}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="506661432"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="1016653387">
-							<int key="NSCellFlags">67239488</int>
+							<int key="NSCellFlags">67108928</int>
 							<int key="NSCellFlags2">71435264</int>
 							<string key="NSContents">Move selection to</string>
 							<reference key="NSSupport" ref="26"/>
@@ -110,31 +113,34 @@
 								<reference key="NSColor" ref="693077508"/>
 							</object>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="142255690">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">265</int>
 						<string key="NSFrame">{{365, 9}, {58, 17}}</string>
 						<reference key="NSSuperview" ref="1005"/>
-						<reference key="NSNextKeyView"/>
+						<reference key="NSWindow"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="52545586">
-							<int key="NSCellFlags">-2080244224</int>
+							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">134348800</int>
 							<string key="NSContents">Move</string>
 							<reference key="NSSupport" ref="26"/>
 							<reference key="NSControlView" ref="142255690"/>
-							<int key="NSButtonFlags">-2038152961</int>
+							<int key="NSButtonFlags">-2038153216</int>
 							<int key="NSButtonFlags2">164</int>
 							<string key="NSAlternateContents"/>
 							<string key="NSKeyEquivalent"/>
 							<int key="NSPeriodicDelay">400</int>
 							<int key="NSPeriodicInterval">75</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 				</object>
 				<string key="NSFrameSize">{443, 36}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="468221191"/>
 				<string key="NSClassName">HFDocumentOperationView</string>
 			</object>
@@ -275,7 +281,7 @@
 					<string>91.IBPluginDependency</string>
 					<string>92.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -304,12 +310,287 @@
 			<nil key="sourceID"/>
 			<int key="maxID">101</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBPartialClassDescription">
+					<string key="className">BaseDataDocument</string>
+					<string key="superclassName">NSDocument</string>
+					<object class="NSMutableDictionary" key="actions">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>decreaseFontSize:</string>
+							<string>deleteBookmark:</string>
+							<string>findNext:</string>
+							<string>findPrevious:</string>
+							<string>increaseFontSize:</string>
+							<string>modifyByteGrouping:</string>
+							<string>moveSelectionByAction:</string>
+							<string>moveSelectionToAction:</string>
+							<string>performFindReplaceActionFromSelectedSegment:</string>
+							<string>replace:</string>
+							<string>replaceAll:</string>
+							<string>replaceAndFind:</string>
+							<string>saveDocument:</string>
+							<string>saveDocumentAs:</string>
+							<string>saveDocumentTo:</string>
+							<string>scrollToBookmark:</string>
+							<string>selectBookmark:</string>
+							<string>setAntialiasFromMenuItem:</string>
+							<string>setBookmark:</string>
+							<string>setInsertMode:</string>
+							<string>setOverwriteMode:</string>
+							<string>setReadOnlyMode:</string>
+							<string>setStringEncodingFromMenuItem:</string>
+							<string>showFontPanel:</string>
+							<string>toggleVisibleControllerView:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>NSMenuItem</string>
+							<string>id</string>
+							<string>id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>decreaseFontSize:</string>
+							<string>deleteBookmark:</string>
+							<string>findNext:</string>
+							<string>findPrevious:</string>
+							<string>increaseFontSize:</string>
+							<string>modifyByteGrouping:</string>
+							<string>moveSelectionByAction:</string>
+							<string>moveSelectionToAction:</string>
+							<string>performFindReplaceActionFromSelectedSegment:</string>
+							<string>replace:</string>
+							<string>replaceAll:</string>
+							<string>replaceAndFind:</string>
+							<string>saveDocument:</string>
+							<string>saveDocumentAs:</string>
+							<string>saveDocumentTo:</string>
+							<string>scrollToBookmark:</string>
+							<string>selectBookmark:</string>
+							<string>setAntialiasFromMenuItem:</string>
+							<string>setBookmark:</string>
+							<string>setInsertMode:</string>
+							<string>setOverwriteMode:</string>
+							<string>setReadOnlyMode:</string>
+							<string>setStringEncodingFromMenuItem:</string>
+							<string>showFontPanel:</string>
+							<string>toggleVisibleControllerView:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBActionInfo">
+								<string key="name">decreaseFontSize:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">deleteBookmark:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">findNext:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">findPrevious:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">increaseFontSize:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">modifyByteGrouping:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">moveSelectionByAction:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">moveSelectionToAction:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">performFindReplaceActionFromSelectedSegment:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replace:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replaceAll:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replaceAndFind:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">saveDocument:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">saveDocumentAs:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">saveDocumentTo:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">scrollToBookmark:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">selectBookmark:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setAntialiasFromMenuItem:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setBookmark:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setInsertMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setOverwriteMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setReadOnlyMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setStringEncodingFromMenuItem:</string>
+								<string key="candidateClassName">NSMenuItem</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">showFontPanel:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">toggleVisibleControllerView:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">containerView</string>
+						<string key="NS.object.0">NSSplitView</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">containerView</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">containerView</string>
+							<string key="candidateClassName">NSSplitView</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/BaseDataDocument.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFDocumentOperationView</string>
+					<string key="superclassName">HFResizingView</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">cancelViewOperation:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">cancelViewOperation:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">cancelViewOperation:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>cancelButton</string>
+							<string>progressIndicator</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>NSButton</string>
+							<string>NSProgressIndicator</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>cancelButton</string>
+							<string>progressIndicator</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">cancelButton</string>
+								<string key="candidateClassName">NSButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">progressIndicator</string>
+								<string key="candidateClassName">NSProgressIndicator</string>
+							</object>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFDocumentOperationView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFResizingView</string>
+					<string key="superclassName">NSView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFResizingView.h</string>
+					</object>
+				</object>
+			</object>
+		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1060" key="NS.object.0"/>
+			<real value="1070" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>

--- a/English.lproj/MoveSelectionByBanner.xib
+++ b/English.lproj/MoveSelectionByBanner.xib
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1050</int>
-		<string key="IBDocument.SystemVersion">11C74</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1938</string>
-		<string key="IBDocument.AppKitVersion">1138.23</string>
-		<string key="IBDocument.HIToolboxVersion">567.00</string>
+		<int key="IBDocument.SystemTarget">1070</int>
+		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1938</string>
+			<string key="NS.object.0">3084</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
+			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSTextField</string>
 			<string>NSTextFieldCell</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSButton</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -52,7 +52,7 @@
 						<reference key="NSNextKeyView" ref="901719687"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="1035097676">
-							<int key="NSCellFlags">-1804468671</int>
+							<int key="NSCellFlags">-1804599231</int>
 							<int key="NSCellFlags2">268567552</int>
 							<string key="NSContents"/>
 							<object class="NSFont" key="NSSupport" id="26">
@@ -81,6 +81,7 @@
 								</object>
 							</object>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="468221191">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -91,7 +92,7 @@
 						<reference key="NSNextKeyView" ref="506661432"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="1016653387">
-							<int key="NSCellFlags">67239488</int>
+							<int key="NSCellFlags">67108928</int>
 							<int key="NSCellFlags2">71435264</int>
 							<string key="NSContents">Move selection by</string>
 							<reference key="NSSupport" ref="26"/>
@@ -112,6 +113,7 @@
 								<reference key="NSColor" ref="693077508"/>
 							</object>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="901719687">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -122,12 +124,12 @@
 						<reference key="NSNextKeyView" ref="142255690"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="920969600">
-							<int key="NSCellFlags">67239424</int>
+							<int key="NSCellFlags">67108864</int>
 							<int key="NSCellFlags2">131072</int>
 							<string key="NSContents">extend selection</string>
 							<reference key="NSSupport" ref="26"/>
 							<reference key="NSControlView" ref="901719687"/>
-							<int key="NSButtonFlags">1211912703</int>
+							<int key="NSButtonFlags">1211912448</int>
 							<int key="NSButtonFlags2">2</int>
 							<object class="NSCustomResource" key="NSNormalImage">
 								<string key="NSClassName">NSImage</string>
@@ -141,6 +143,7 @@
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="142255690">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -148,21 +151,21 @@
 						<string key="NSFrame">{{365, 9}, {58, 17}}</string>
 						<reference key="NSSuperview" ref="1005"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="52545586">
-							<int key="NSCellFlags">-2080244224</int>
+							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">134348800</int>
 							<string key="NSContents">Move</string>
 							<reference key="NSSupport" ref="26"/>
 							<reference key="NSControlView" ref="142255690"/>
-							<int key="NSButtonFlags">-2038152961</int>
+							<int key="NSButtonFlags">-2038153216</int>
 							<int key="NSButtonFlags2">164</int>
 							<string key="NSAlternateContents"/>
 							<string key="NSKeyEquivalent"/>
 							<int key="NSPeriodicDelay">400</int>
 							<int key="NSPeriodicInterval">75</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 				</object>
 				<string key="NSFrameSize">{443, 36}</string>
@@ -334,7 +337,7 @@
 					<string>91.IBPluginDependency</string>
 					<string>92.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -389,11 +392,13 @@
 							<string>replaceAndFind:</string>
 							<string>setAntialiasFromMenuItem:</string>
 							<string>setBookmark:</string>
+							<string>setInsertMode:</string>
+							<string>setOverwriteMode:</string>
+							<string>setReadOnlyMode:</string>
 							<string>setStringEncodingFromMenuItem:</string>
 							<string>showFontPanel:</string>
-							<string>toggleOverwriteMode:</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
+						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>id</string>
 							<string>id</string>
@@ -408,8 +413,10 @@
 							<string>id</string>
 							<string>id</string>
 							<string>id</string>
-							<string>NSMenuItem</string>
 							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>NSMenuItem</string>
 							<string>id</string>
 						</object>
 					</object>
@@ -430,11 +437,13 @@
 							<string>replaceAndFind:</string>
 							<string>setAntialiasFromMenuItem:</string>
 							<string>setBookmark:</string>
+							<string>setInsertMode:</string>
+							<string>setOverwriteMode:</string>
+							<string>setReadOnlyMode:</string>
 							<string>setStringEncodingFromMenuItem:</string>
 							<string>showFontPanel:</string>
-							<string>toggleOverwriteMode:</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
+						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<object class="IBActionInfo">
 								<string key="name">decreaseFontSize:</string>
@@ -489,15 +498,23 @@
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
+								<string key="name">setInsertMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setOverwriteMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setReadOnlyMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
 								<string key="name">setStringEncodingFromMenuItem:</string>
 								<string key="candidateClassName">NSMenuItem</string>
 							</object>
 							<object class="IBActionInfo">
 								<string key="name">showFontPanel:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">toggleOverwriteMode:</string>
 								<string key="candidateClassName">id</string>
 							</object>
 						</object>
@@ -532,6 +549,38 @@
 							<string key="candidateClassName">id</string>
 						</object>
 					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>cancelButton</string>
+							<string>progressIndicator</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>NSButton</string>
+							<string>NSProgressIndicator</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>cancelButton</string>
+							<string>progressIndicator</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">cancelButton</string>
+								<string key="candidateClassName">NSButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">progressIndicator</string>
+								<string key="candidateClassName">NSProgressIndicator</string>
+							</object>
+						</object>
+					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
 						<string key="minorKey">./Classes/HFDocumentOperationView.h</string>
@@ -545,80 +594,13 @@
 						<string key="minorKey">./Classes/HFResizingView.h</string>
 					</object>
 				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSDocument</string>
-					<object class="NSMutableDictionary" key="actions">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>printDocument:</string>
-							<string>revertDocumentToSaved:</string>
-							<string>runPageLayout:</string>
-							<string>saveDocument:</string>
-							<string>saveDocumentAs:</string>
-							<string>saveDocumentTo:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>printDocument:</string>
-							<string>revertDocumentToSaved:</string>
-							<string>runPageLayout:</string>
-							<string>saveDocument:</string>
-							<string>saveDocumentAs:</string>
-							<string>saveDocumentTo:</string>
-						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBActionInfo">
-								<string key="name">printDocument:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">revertDocumentToSaved:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">runPageLayout:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">saveDocument:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">saveDocumentAs:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">saveDocumentTo:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NSDocument.h</string>
-					</object>
-				</object>
 			</object>
 		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1050" key="NS.object.0"/>
+			<real value="1070" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>

--- a/English.lproj/SaveBanner.xib
+++ b/English.lproj/SaveBanner.xib
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1050</int>
-		<string key="IBDocument.SystemVersion">11C74</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1938</string>
-		<string key="IBDocument.AppKitVersion">1138.23</string>
-		<string key="IBDocument.HIToolboxVersion">567.00</string>
+		<int key="IBDocument.SystemTarget">1070</int>
+		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1938</string>
+			<string key="NS.object.0">3084</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
+			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSTextField</string>
-			<string>NSButtonCell</string>
 			<string>NSTextFieldCell</string>
-			<string>NSButton</string>
-			<string>NSCustomObject</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -48,10 +48,10 @@
 						<int key="NSvFlags">258</int>
 						<string key="NSFrame">{{55, 5}, {392, 14}}</string>
 						<reference key="NSSuperview" ref="1005"/>
-						<reference key="NSNextKeyView"/>
+						<reference key="NSWindow"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="677922081">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272761856</int>
 							<string key="NSContents">Saving "SomeDocument"</string>
 							<object class="NSFont" key="NSSupport">
@@ -79,16 +79,18 @@
 								</object>
 							</object>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="342010705">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">-2147483388</int>
 						<string key="NSFrame">{{30, 7}, {11, 11}}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="758443218"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="774131558">
-							<int key="NSCellFlags">67239424</int>
+							<int key="NSCellFlags">67108864</int>
 							<int key="NSCellFlags2">134217728</int>
 							<string key="NSContents"/>
 							<object class="NSFont" key="NSSupport">
@@ -97,25 +99,28 @@
 								<int key="NSfFlags">1044</int>
 							</object>
 							<reference key="NSControlView" ref="342010705"/>
-							<int key="NSButtonFlags">-2041298689</int>
+							<int key="NSButtonFlags">-2041298944</int>
 							<int key="NSButtonFlags2">134</int>
 							<string key="NSAlternateContents"/>
 							<string key="NSKeyEquivalent"/>
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSCustomView" id="1045295722">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">268</int>
 						<string key="NSFrameSize">{464, 24}</string>
 						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="342010705"/>
 						<string key="NSClassName">StretchableProgressIndicator</string>
 					</object>
 				</object>
 				<string key="NSFrameSize">{464, 24}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="1045295722"/>
 				<string key="NSClassName">HFDocumentOperationView</string>
 			</object>
@@ -248,7 +253,7 @@
 					<string>49.IBPluginDependency</string>
 					<string>51.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -282,12 +287,254 @@
 			<nil key="sourceID"/>
 			<int key="maxID">56</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBPartialClassDescription">
+					<string key="className">BaseDataDocument</string>
+					<string key="superclassName">NSDocument</string>
+					<object class="NSMutableDictionary" key="actions">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>decreaseFontSize:</string>
+							<string>deleteBookmark:</string>
+							<string>findNext:</string>
+							<string>findPrevious:</string>
+							<string>increaseFontSize:</string>
+							<string>modifyByteGrouping:</string>
+							<string>moveSelectionByAction:</string>
+							<string>performFindReplaceActionFromSelectedSegment:</string>
+							<string>replace:</string>
+							<string>replaceAll:</string>
+							<string>replaceAndFind:</string>
+							<string>setAntialiasFromMenuItem:</string>
+							<string>setBookmark:</string>
+							<string>setInsertMode:</string>
+							<string>setOverwriteMode:</string>
+							<string>setReadOnlyMode:</string>
+							<string>setStringEncodingFromMenuItem:</string>
+							<string>showFontPanel:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>id</string>
+							<string>NSMenuItem</string>
+							<string>id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>decreaseFontSize:</string>
+							<string>deleteBookmark:</string>
+							<string>findNext:</string>
+							<string>findPrevious:</string>
+							<string>increaseFontSize:</string>
+							<string>modifyByteGrouping:</string>
+							<string>moveSelectionByAction:</string>
+							<string>performFindReplaceActionFromSelectedSegment:</string>
+							<string>replace:</string>
+							<string>replaceAll:</string>
+							<string>replaceAndFind:</string>
+							<string>setAntialiasFromMenuItem:</string>
+							<string>setBookmark:</string>
+							<string>setInsertMode:</string>
+							<string>setOverwriteMode:</string>
+							<string>setReadOnlyMode:</string>
+							<string>setStringEncodingFromMenuItem:</string>
+							<string>showFontPanel:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBActionInfo">
+								<string key="name">decreaseFontSize:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">deleteBookmark:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">findNext:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">findPrevious:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">increaseFontSize:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">modifyByteGrouping:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">moveSelectionByAction:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">performFindReplaceActionFromSelectedSegment:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replace:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replaceAll:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">replaceAndFind:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setAntialiasFromMenuItem:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setBookmark:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setInsertMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setOverwriteMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setReadOnlyMode:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">setStringEncodingFromMenuItem:</string>
+								<string key="candidateClassName">NSMenuItem</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">showFontPanel:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">containerView</string>
+						<string key="NS.object.0">NSSplitView</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">containerView</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">containerView</string>
+							<string key="candidateClassName">NSSplitView</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/BaseDataDocument.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFCancelButton</string>
+					<string key="superclassName">NSButton</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFCancelButton.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFDocumentOperationView</string>
+					<string key="superclassName">HFResizingView</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">cancelViewOperation:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">cancelViewOperation:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">cancelViewOperation:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>cancelButton</string>
+							<string>progressIndicator</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>NSButton</string>
+							<string>NSProgressIndicator</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>cancelButton</string>
+							<string>progressIndicator</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">cancelButton</string>
+								<string key="candidateClassName">NSButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">progressIndicator</string>
+								<string key="candidateClassName">NSProgressIndicator</string>
+							</object>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFDocumentOperationView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">HFResizingView</string>
+					<string key="superclassName">NSView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/HFResizingView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">StretchableProgressIndicator</string>
+					<string key="superclassName">NSProgressIndicator</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/StretchableProgressIndicator.h</string>
+					</object>
+				</object>
+			</object>
+		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1050" key="NS.object.0"/>
+			<real value="1070" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>

--- a/HexFiend_2.xcodeproj/project.pbxproj
+++ b/HexFiend_2.xcodeproj/project.pbxproj
@@ -1589,7 +1589,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				"MACOSX_DEPLOYMENT_TARGET[arch=ppc64]" = 10.5;
 				SDKROOT = macosx;
 				"SDKROOT[arch=ppc64]" = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
@@ -1734,7 +1734,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				"MACOSX_DEPLOYMENT_TARGET[arch=ppc64]" = 10.5;
 				SDKROOT = macosx;
 				"SDKROOT[arch=ppc64]" = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
@@ -1879,7 +1879,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				"MACOSX_DEPLOYMENT_TARGET[arch=ppc64]" = 10.5;
 				SDKROOT = macosx;
 				"SDKROOT[arch=ppc64]" = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
@@ -2064,7 +2064,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				"MACOSX_DEPLOYMENT_TARGET[arch=ppc64]" = 10.5;
 				SDKROOT = macosx;
 				"SDKROOT[arch=ppc64]" = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
@@ -2209,7 +2209,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				"MACOSX_DEPLOYMENT_TARGET[arch=ppc64]" = 10.5;
 				SDKROOT = macosx;
 				"SDKROOT[arch=ppc64]" = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";

--- a/app/sources/BaseDataDocument.m
+++ b/app/sources/BaseDataDocument.m
@@ -487,7 +487,7 @@ static inline Class preferredByteArrayClass(void) {
     [layoutRepresenter performLayout];
 }
 
-- init {
+- (id)init {
     self = [super init];
     
     /* Make sure we register our defaults for this class */
@@ -999,7 +999,7 @@ static inline Class preferredByteArrayClass(void) {
     
     [[controller byteArray] incrementChangeLockCounter];
     
-    [[saveView viewNamed:@"saveLabelField"] setStringValue:[NSString stringWithFormat:@"Saving \"%@\"", [self displayName]]];
+    [(NSTextField*)[saveView viewNamed:@"saveLabelField"] setStringValue:[NSString stringWithFormat:@"Saving \"%@\"", [self displayName]]];
 
     __block NSInteger saveResult = 0;
     [saveView startOperation:^id(HFProgressTracker *tracker) {
@@ -1115,10 +1115,10 @@ static inline Class preferredByteArrayClass(void) {
     
     if (! findReplaceView) {
         findReplaceView = [self newOperationViewForNibName:@"FindReplaceBanner" displayName:@"Finding" fixedHeight:NO];
-        [[findReplaceView viewNamed:@"searchField"] setTarget:self];
-        [[findReplaceView viewNamed:@"searchField"] setAction:@selector(findNext:)];
-        [[findReplaceView viewNamed:@"replaceField"] setTarget:self];
-        [[findReplaceView viewNamed:@"replaceField"] setAction:@selector(findNext:)]; //yes, this should be findNext:, not replace:, because when you just hit return in the replace text field, it only finds; replace is for the replace button
+        [(HFTextField*)[findReplaceView viewNamed:@"searchField"] setTarget:self];
+        [(HFTextField*)[findReplaceView viewNamed:@"searchField"] setAction:@selector(findNext:)];
+        [(HFTextField*)[findReplaceView viewNamed:@"replaceField"] setTarget:self];
+        [(HFTextField*)[findReplaceView viewNamed:@"replaceField"] setAction:@selector(findNext:)]; //yes, this should be findNext:, not replace:, because when you just hit return in the replace text field, it only finds; replace is for the replace button
     }
     
     [self prepareBannerWithView:findReplaceView withTargetFirstResponder:[findReplaceView viewNamed:@"searchField"]];
@@ -1261,7 +1261,7 @@ static inline Class preferredByteArrayClass(void) {
         NSBeep();
         return;
     }
-    HFByteArray *needle = [[findReplaceView viewNamed:@"searchField"] objectValue];
+    HFByteArray *needle = [(HFTextField*)[findReplaceView viewNamed:@"searchField"] objectValue];
     if ([needle length] > 0) {
         HFByteArray *haystack = [controller byteArray];
         unsigned long long startLocation = [controller maximumSelectionLocation];
@@ -1356,7 +1356,7 @@ cancelled:;
         NSBeep();
         return;
     }
-    HFByteArray *replaceArray = [[findReplaceView viewNamed:@"replaceField"] objectValue];
+    HFByteArray *replaceArray = [(HFTextField*)[findReplaceView viewNamed:@"replaceField"] objectValue];
     HFASSERT(replaceArray != NULL);
     [controller insertByteArray:replaceArray replacingPreviousBytes:0 allowUndoCoalescing:NO];
     
@@ -1377,12 +1377,12 @@ cancelled:;
         NSBeep();
         return;
     }
-    HFByteArray *needle = [[findReplaceView viewNamed:@"searchField"] objectValue];
+    HFByteArray *needle = [(HFTextField*)[findReplaceView viewNamed:@"searchField"] objectValue];
     if ([needle length] == 0) {
         NSBeep();
         return;
     }
-    HFByteArray *replacementValue = [[findReplaceView viewNamed:@"replaceField"] objectValue];
+    HFByteArray *replacementValue = [(HFTextField*)[findReplaceView viewNamed:@"replaceField"] objectValue];
     HFASSERT(replacementValue != NULL);
     HFByteArray *haystack = [controller byteArray];
     
@@ -1432,12 +1432,12 @@ cancelled:;
 
 - (void)showNavigationBannerSettingExtendSelectionCheckboxTo:(BOOL)extend {
     if (moveSelectionByView == operationView && moveSelectionByView != nil) {
-        [[moveSelectionByView viewNamed:@"extendSelectionByCheckbox"] setIntValue:extend];
+        [(NSButton*)[moveSelectionByView viewNamed:@"extendSelectionByCheckbox"] setIntValue:extend];
         [self saveFirstResponderIfNotInBannerAndThenSetItTo:[moveSelectionByView viewNamed:@"moveSelectionByTextField"]];
         return;
     }
     if (! moveSelectionByView) moveSelectionByView = [self newOperationViewForNibName:@"MoveSelectionByBanner" displayName:@"Moving Selection" fixedHeight:YES];
-    [[moveSelectionByView viewNamed:@"extendSelectionByCheckbox"] setIntValue:extend];
+    [(NSButton*)[moveSelectionByView viewNamed:@"extendSelectionByCheckbox"] setIntValue:extend];
     [self prepareBannerWithView:moveSelectionByView withTargetFirstResponder:[moveSelectionByView viewNamed:@"moveSelectionByTextField"]];
     
 }
@@ -1502,7 +1502,7 @@ cancelled:;
     BOOL success = NO;
     unsigned long long value;
     unsigned isNegative;
-    if (parseNumericStringWithSuffix([[jumpToOffsetView viewNamed:@"moveSelectionByTextField"] stringValue], &value, &isNegative)) {
+    if (parseNumericStringWithSuffix([(NSTextField*)[jumpToOffsetView viewNamed:@"moveSelectionByTextField"] stringValue], &value, &isNegative)) {
         unsigned long long length = [controller contentsLength];
         if (length >= value) {
             const unsigned long long offset = (isNegative ? length - value : value);
@@ -1521,9 +1521,9 @@ cancelled:;
     BOOL success = NO;
     unsigned long long value;
     unsigned isNegative;
-    if (parseNumericStringWithSuffix([[moveSelectionByView viewNamed:@"moveSelectionByTextField"] stringValue], &value, &isNegative)) {
+    if (parseNumericStringWithSuffix([(NSTextField*)[moveSelectionByView viewNamed:@"moveSelectionByTextField"] stringValue], &value, &isNegative)) {
         if ([self movingRanges:[controller selectedContentsRanges] byAmount:value isNegative:isNegative isValidForLength:[controller contentsLength]]) {
-            BOOL extendSelection = !![[moveSelectionByView viewNamed:@"extendSelectionByCheckbox"] intValue];
+            BOOL extendSelection = !![(NSTextField*)[moveSelectionByView viewNamed:@"extendSelectionByCheckbox"] intValue];
             HFControllerMovementDirection direction = (isNegative ? HFControllerDirectionLeft : HFControllerDirectionRight);
             HFControllerSelectionTransformation transformation = (extendSelection ? HFControllerExtendSelection : HFControllerShiftSelection);
             [controller moveInDirection:direction byByteCount:value withSelectionTransformation:transformation usingAnchor:NO];
@@ -1585,7 +1585,7 @@ cancelled:;
         NSMenuItem *item;
         
         item = [bookmarksMenu itemAtIndex:itemIndex++];
-        [item setTitle:[NSString stringWithFormat:@"Select Bookmark %lu", bookmarkIndex]];
+        [item setTitle:[NSString stringWithFormat:@"Select Bookmark %lu", (unsigned long)bookmarkIndex]];
         [item setKeyEquivalent:keString];
         [item setAction:@selector(selectBookmark:)];
         [item setKeyEquivalentModifierMask:NSCommandKeyMask];
@@ -1597,7 +1597,7 @@ cancelled:;
         [item setAction:@selector(scrollToBookmark:)];
         [item setKeyEquivalentModifierMask:NSCommandKeyMask | NSShiftKeyMask];
         [item setAlternate:YES];
-        [item setTitle:[NSString stringWithFormat:@"Scroll to Bookmark %lu", bookmarkIndex]];
+        [item setTitle:[NSString stringWithFormat:@"Scroll to Bookmark %lu", (unsigned long)bookmarkIndex]];
         [item setTag:bookmarkIndex];
         
         [keString release];

--- a/app/sources/DiffDocument.m
+++ b/app/sources/DiffDocument.m
@@ -821,13 +821,13 @@ static enum DiffOverlayViewRangeType_t rangeTypeForValue(CGFloat value) {
         }
         
         if (insn.src.length == 0) {
-            return [NSString stringWithFormat:@"%lu: Insert %@ at offset 0x%llx", row + 1, HFDescribeByteCount(insn.dst.length), insn.dst.location];
+            return [NSString stringWithFormat:@"%ld: Insert %@ at offset 0x%llx", (long)row + 1, HFDescribeByteCount(insn.dst.length), insn.dst.location];
         }
         else if (insn.dst.length == 0) {
-            return [NSString stringWithFormat:@"%lu: Delete %@ at offset 0x%llx", row + 1, HFDescribeByteCount(insn.src.length), insn.src.location];
+            return [NSString stringWithFormat:@"%ld: Delete %@ at offset 0x%llx", (long)row + 1, HFDescribeByteCount(insn.src.length), insn.src.location];
         }
         else {
-            return [NSString stringWithFormat:@"%lu: Replace %@ at offset 0x%llx with %@", row + 1, HFDescribeByteCount(insn.src.length), insn.src.location, HFDescribeByteCount(insn.dst.length)];
+            return [NSString stringWithFormat:@"%ld: Replace %@ at offset 0x%llx with %@", (long)row + 1, HFDescribeByteCount(insn.src.length), insn.src.location, HFDescribeByteCount(insn.dst.length)];
         }
     }
 }

--- a/app/sources/HFDocumentOperationView.h
+++ b/app/sources/HFDocumentOperationView.h
@@ -30,9 +30,9 @@
 
 - (void)setOtherTopLevelObjects:(NSArray *)objects;
 
-+ viewWithNibNamed:(NSString *)name owner:(id)owner;
++ (HFDocumentOperationView *)viewWithNibNamed:(NSString *)name owner:(id)owner;
 
-- viewNamed:(NSString *)name;
+- (NSView *)viewNamed:(NSString *)name;
 
 - (CGFloat)defaultHeight;
 

--- a/app/sources/HFDocumentOperationView.m
+++ b/app/sources/HFDocumentOperationView.m
@@ -24,7 +24,7 @@ static NSString *sNibName;
 
 @implementation HFDocumentOperationView
 
-+ viewWithNibNamed:(NSString *)name owner:(id)owner {
++ (HFDocumentOperationView *)viewWithNibNamed:(NSString *)name owner:(id)owner {
     NSString *path = [[NSBundle bundleForClass:self] pathForResource:name ofType:@"nib"];
     if (! path) [NSException raise:NSInvalidArgumentException format:@"Unable to find nib named %@", name];
     sNibName = [name copy];
@@ -77,7 +77,7 @@ static NSString *sNibName;
 }
 
 
-- initWithFrame:(NSRect)frame {
+- (id)initWithFrame:(NSRect)frame {
     self = [super initWithFrame:frame];
     defaultSize = frame.size;
     nibName = [sNibName copy];
@@ -110,7 +110,7 @@ static NSView *searchForViewWithIdentifier(NSView *view, NSString *identifier) {
     return result;
 }
 
-- viewNamed:(NSString *)name {
+- (NSView *)viewNamed:(NSString *)name {
     NSView *view = searchForViewWithIdentifier(self, name);
     if (! view) [NSException raise:NSInvalidArgumentException format:@"No view named %@ in nib %@", name, nibName];
     return view;

--- a/app/sources/HFFindReplaceBackgroundView.m
+++ b/app/sources/HFFindReplaceBackgroundView.m
@@ -88,7 +88,7 @@ static CGFloat roundTowardsInfinity(CGFloat x) {
     return cancelButton;
 }
 
-- initWithFrame:(NSRect)rect {
+- (id)initWithFrame:(NSRect)rect {
     self = [super initWithFrame:rect];
     defaultHeight = NSHeight(rect);
     return self;

--- a/app/sources/HFFindReplaceOperationView.m
+++ b/app/sources/HFFindReplaceOperationView.m
@@ -10,7 +10,7 @@
 
 @implementation HFFindReplaceOperationView
 
-- initWithFrame:(NSRect)frame {
+- (id)initWithFrame:(NSRect)frame {
     self = [super initWithFrame:frame];
     fieldTypeIsASCII = 	[[NSUserDefaults standardUserDefaults] boolForKey:@"FindPrefersASCII"];
     return self;

--- a/framework/sources/BTree/BTree_Testing/NaiveArray.m
+++ b/framework/sources/BTree/BTree_Testing/NaiveArray.m
@@ -16,7 +16,7 @@
 
 @implementation NaiveArray
 
-- init {
+- (id)init {
     self = [super init];
     entries = [[NSMutableArray alloc] init];
     return self;

--- a/framework/sources/HFBTreeByteArray.h
+++ b/framework/sources/HFBTreeByteArray.h
@@ -25,6 +25,6 @@ Create an HFBTreeByteArray via \c -init.  It has no methods other than those on 
 
 /*! Designated initializer for HFBTreeByteArray.
 */
-- init;
+- (id)init;
 
 @end

--- a/framework/sources/HFBTreeByteArray.m
+++ b/framework/sources/HFBTreeByteArray.m
@@ -13,7 +13,7 @@
 
 @implementation HFBTreeByteArray
 
-- init {
+- (id)init {
     if ((self = [super init])) {
         btree = [[HFBTree alloc] init];
     }
@@ -245,7 +245,7 @@ static inline HFByteSlice *findInitialSlice(HFBTree *btree, HFRange *inoutArrayR
     }
 }
 
-- mutableCopyWithZone:(NSZone *)zone {
+- (id)mutableCopyWithZone:(NSZone *)zone {
     USE(zone);
     HFBTreeByteArray *result = [[[self class] alloc] init];
     [result->btree release];
@@ -253,7 +253,7 @@ static inline HFByteSlice *findInitialSlice(HFBTree *btree, HFRange *inoutArrayR
     return result;
 }
 
-- subarrayWithRange:(HFRange)range {
+- (id)subarrayWithRange:(HFRange)range {
     if (range.location == 0 && range.length == [self length]) {
         return [[self mutableCopy] autorelease];
     }

--- a/framework/sources/HFByteArray.m
+++ b/framework/sources/HFByteArray.m
@@ -11,7 +11,7 @@
 
 @implementation HFByteArray
 
-- init {
+- (id)init {
     if ([self class] == [HFByteArray class]) {
         [NSException raise:NSInvalidArgumentException format:@"init sent to HFByteArray, but HFByteArray is an abstract class.  Instantiate one of its subclasses instead, like HFBTreeByteArray."];
     }
@@ -72,12 +72,12 @@
 
 - (HFByteArray *)subarrayWithRange:(HFRange)range { USE(range); UNIMPLEMENTED(); }
 
-- mutableCopyWithZone:(NSZone *)zone {
+- (id)mutableCopyWithZone:(NSZone *)zone {
     USE(zone);
     return [[self subarrayWithRange:HFRangeMake(0, [self length])] retain];
 }
 
-- copyWithZone:(NSZone *)zone {
+- (id)copyWithZone:(NSZone *)zone {
     USE(zone);
     return [[self subarrayWithRange:HFRangeMake(0, [self length])] retain];
 }

--- a/framework/sources/HFByteArray_FindReplace.m
+++ b/framework/sources/HFByteArray_FindReplace.m
@@ -306,7 +306,7 @@ cancelled:
     unsigned long long result = ULLONG_MAX;
     const int tempCancelRequested = 0;
     volatile unsigned long long * const progressValuePtr = (progressTracker ? &progressTracker->currentProgress : &tempProgressValue);
-    volatile int *cancelRequested = (progressTracker ? &progressTracker->cancelRequested : &tempCancelRequested);
+    const volatile int *cancelRequested = (progressTracker ? &progressTracker->cancelRequested : &tempCancelRequested);
     
     unsigned char buff[SEARCH_CHUNK_SIZE];
     

--- a/framework/sources/HFByteRangeAttribute.m
+++ b/framework/sources/HFByteRangeAttribute.m
@@ -37,7 +37,7 @@ NSString *HFBookmarkAttributeFromBookmark(NSInteger bookmark) {
         return sStaticBookmarkStrings[bookmark];
     }
     else {
-        return [NSString stringWithFormat:BOOKMARK_PREFIX @"%ld", bookmark];
+        return [NSString stringWithFormat:BOOKMARK_PREFIX @"%ld", (long)bookmark];
     }
 }
 

--- a/framework/sources/HFByteSlice.h
+++ b/framework/sources/HFByteSlice.h
@@ -31,7 +31,7 @@ The two principal subclasses of HFByteSlice are HFSharedMemoryByteSlice and HFFi
 
 /*! Attempts to create a new byte slice by appending one byte slice to another.  This does not modify the receiver or the slice argument (after all, both are immutable).  This is provided as an optimization, and is allowed to return nil if the appending cannot be done efficiently.  The default implementation returns nil.
 */
-- (id)byteSliceByAppendingSlice:(HFByteSlice *)slice;
+- (HFByteSlice *)byteSliceByAppendingSlice:(HFByteSlice *)slice;
 
 /*! Returns YES if the receiver is sourced from a file.  The default implementation returns NO.  This is used to estimate cost when writing to a file.
 */

--- a/framework/sources/HFByteSlice.m
+++ b/framework/sources/HFByteSlice.m
@@ -10,7 +10,7 @@
 
 @implementation HFByteSlice
 
-- init {
+- (id)init {
     if ([self class] == [HFByteSlice class]) {
         [NSException raise:NSInvalidArgumentException format:@"init sent to HFByteArray, but HFByteArray is an abstract class.  Instantiate one of its subclasses instead."];
     }
@@ -48,7 +48,7 @@
     }
 }
 
-- byteSliceByAppendingSlice:(HFByteSlice *)slice {
+- (HFByteSlice *)byteSliceByAppendingSlice:(HFByteSlice *)slice {
     USE(slice);
     return nil;
 }

--- a/framework/sources/HFByteSliceFileOperation.h
+++ b/framework/sources/HFByteSliceFileOperation.h
@@ -18,11 +18,11 @@ typedef enum {
     HFRange targetRange;
 }
 
-+ identityOperationWithByteSlice:(HFByteSlice *)slice targetRange:(HFRange)range;
-+ externalOperationWithByteSlice:(HFByteSlice *)slice targetRange:(HFRange)range;
-+ internalOperationWithByteSlice:(HFByteSlice *)slice sourceRange:(HFRange)source targetRange:(HFRange)target;
++ (id)identityOperationWithByteSlice:(HFByteSlice *)slice targetRange:(HFRange)range;
++ (id)externalOperationWithByteSlice:(HFByteSlice *)slice targetRange:(HFRange)range;
++ (id)internalOperationWithByteSlice:(HFByteSlice *)slice sourceRange:(HFRange)source targetRange:(HFRange)target;
 
-+ chainedOperationWithInternalOperations:(NSArray *)internalOperations;
++ (id)chainedOperationWithInternalOperations:(NSArray *)internalOperations;
 
 - (HFRange)sourceRange;
 - (HFRange)targetRange;

--- a/framework/sources/HFByteSliceFileOperation.m
+++ b/framework/sources/HFByteSliceFileOperation.m
@@ -22,20 +22,20 @@ enum {
 #define LOG_IO if (SHOULD_LOG_IO) 
 
 @interface HFByteSliceFileOperation (HFForwardDeclares)
-- initWithTargetRange:(HFRange)range;
+- (id)initWithTargetRange:(HFRange)range;
 @end
 
 @interface HFByteSliceFileOperationSimple : HFByteSliceFileOperation {
     HFByteSlice *slice;
 }
 
-- initWithByteSlice:(HFByteSlice *)val targetRange:(HFRange)range;
+- (id)initWithByteSlice:(HFByteSlice *)val targetRange:(HFRange)range;
 
 @end
 
 @implementation HFByteSliceFileOperationSimple
 
-- initWithByteSlice:(HFByteSlice *)val targetRange:(HFRange)range {
+- (id)initWithByteSlice:(HFByteSlice *)val targetRange:(HFRange)range {
     self = [super initWithTargetRange:range];
     REQUIRE_NOT_NULL(val);
     HFASSERT([val length] == range.length);
@@ -114,7 +114,7 @@ bail:;
     HFRange sourceRange;
 }
 
-- initWithByteSlice:(HFByteSlice *)val sourceRange:(HFRange)source targetRange:(HFRange)target;
+- (id)initWithByteSlice:(HFByteSlice *)val sourceRange:(HFRange)source targetRange:(HFRange)target;
 
 - (BOOL)hasRemainingTargetRange;
 - (HFByteSliceFileOperationQueueEntry *)createQueueEntryWithBuffer:(unsigned char *)buffer ofLength:(NSUInteger)length forFile:(HFFileReference *)file trackingProgress:(HFProgressTracker *)progressTracker NS_RETURNS_RETAINED;
@@ -131,7 +131,7 @@ bail:;
     return [NSString stringWithFormat:@"<%@: %p (%@ -> %@)>", NSStringFromClass([self class]), self, HFRangeToString([self sourceRange]), HFRangeToString([self targetRange])];
 }
 
-- initWithByteSlice:(HFByteSlice *)val sourceRange:(HFRange)source targetRange:(HFRange)target {
+- (id)initWithByteSlice:(HFByteSlice *)val sourceRange:(HFRange)source targetRange:(HFRange)target {
     self = [super initWithTargetRange:target];
     REQUIRE_NOT_NULL(val);
     HFASSERT([val length] == source.length);
@@ -333,13 +333,13 @@ bail:;
     NSUInteger maximumAllocatedMemory;
 }
 
-- initWithInternalOperations:(NSArray *)ops;
+- (id)initWithInternalOperations:(NSArray *)ops;
 
 @end
 
 @implementation HFByteSliceFileOperationChained
 
-- initWithInternalOperations:(NSArray *)ops {
+- (id)initWithInternalOperations:(NSArray *)ops {
     REQUIRE_NOT_NULL(ops);
     self = [super initWithTargetRange:HFRangeMake(ULLONG_MAX, ULLONG_MAX)];
     maximumAllocatedMemory = 1024 * 1024 * 4;
@@ -448,23 +448,23 @@ bail:;
 
 @implementation HFByteSliceFileOperation
 
-+ identityOperationWithByteSlice:(HFByteSlice *)slice targetRange:(HFRange)range {
++ (id)identityOperationWithByteSlice:(HFByteSlice *)slice targetRange:(HFRange)range {
     return [[[HFByteSliceFileOperationIdentity alloc] initWithByteSlice:slice targetRange:range] autorelease];
 }
 
-+ externalOperationWithByteSlice:(HFByteSlice *)slice targetRange:(HFRange)range {
++ (id)externalOperationWithByteSlice:(HFByteSlice *)slice targetRange:(HFRange)range {
     return [[[HFByteSliceFileOperationExternal alloc] initWithByteSlice:slice targetRange:range] autorelease];
 }
 
-+ internalOperationWithByteSlice:(HFByteSlice *)slice sourceRange:(HFRange)source targetRange:(HFRange)target {
++ (id)internalOperationWithByteSlice:(HFByteSlice *)slice sourceRange:(HFRange)source targetRange:(HFRange)target {
     return [[[HFByteSliceFileOperationInternal alloc] initWithByteSlice:slice sourceRange:source targetRange:target] autorelease];
 }
 
-+ chainedOperationWithInternalOperations:(NSArray *)internalOperations {
++ (id)chainedOperationWithInternalOperations:(NSArray *)internalOperations {
     return [[[HFByteSliceFileOperationChained alloc] initWithInternalOperations:internalOperations] autorelease];
 }
 
-- initWithTargetRange:(HFRange)range {
+- (id)initWithTargetRange:(HFRange)range {
     self = [super init];
     HFASSERT(! [self isMemberOfClass:[HFByteSliceFileOperation class]]);
     targetRange = range;

--- a/framework/sources/HFCancelButton.m
+++ b/framework/sources/HFCancelButton.m
@@ -27,7 +27,7 @@
     return self;
 }
 
-- initWithCoder:(NSCoder *)coder {
+- (id)initWithCoder:(NSCoder *)coder {
     if ((self = [super initWithCoder:coder])) {
 	NSImage *stopImage = [NSImage imageNamed:@"NSStopProgressTemplate"];
 	if (stopImage) {

--- a/framework/sources/HFControllerCoalescedUndo.h
+++ b/framework/sources/HFControllerCoalescedUndo.h
@@ -20,9 +20,9 @@
 }
 
 /* replacedData may be nil if it should be considered empty */
-- initWithReplacedData:(HFByteArray *)replacedData atAnchorLocation:(unsigned long long)anchor;
+- (id)initWithReplacedData:(HFByteArray *)replacedData atAnchorLocation:(unsigned long long)anchor;
 
-- initWithOverwrittenData:(HFByteArray *)overwrittenData atAnchorLocation:(unsigned long long)anchor;
+- (id)initWithOverwrittenData:(HFByteArray *)overwrittenData atAnchorLocation:(unsigned long long)anchor;
 
 - (BOOL)canCoalesceAppendInRange:(HFRange)range;
 - (BOOL)canCoalesceDeleteInRange:(HFRange)range;

--- a/framework/sources/HFControllerCoalescedUndo.m
+++ b/framework/sources/HFControllerCoalescedUndo.m
@@ -17,7 +17,7 @@
 
 @implementation HFControllerCoalescedUndo
 
-- initWithReplacedData:(HFByteArray *)replacedData atAnchorLocation:(unsigned long long)anchor  {
+- (id)initWithReplacedData:(HFByteArray *)replacedData atAnchorLocation:(unsigned long long)anchor  {
     self = [super init];
     deletedData = [replacedData retain];
     byteArrayWasCopied = NO;
@@ -30,7 +30,7 @@
     return self;
 }
 
-- initWithOverwrittenData:(HFByteArray *)overwrittenData atAnchorLocation:(unsigned long long)anchor {
+- (id)initWithOverwrittenData:(HFByteArray *)overwrittenData atAnchorLocation:(unsigned long long)anchor {
     self = [super init];
     HFASSERT([overwrittenData length] > 0);
     deletedData = [overwrittenData retain];

--- a/framework/sources/HFFileByteSlice.h
+++ b/framework/sources/HFFileByteSlice.h
@@ -21,9 +21,9 @@
 }
 
 /*! Initialize an HFByteSlice from a file.  The receiver represents the entire extent of the file. */
-- initWithFile:(HFFileReference *)file;
+- (id)initWithFile:(HFFileReference *)file;
 
 /*! Initialize an HFByteSlice from a portion of a file, specified as an offset and length.  The sum of the offset and length must not exceed the length of the file.  This is the designated initializer. */
-- initWithFile:(HFFileReference *)file offset:(unsigned long long)offset length:(unsigned long long)length;
+- (id)initWithFile:(HFFileReference *)file offset:(unsigned long long)offset length:(unsigned long long)length;
 
 @end

--- a/framework/sources/HFFileByteSlice.m
+++ b/framework/sources/HFFileByteSlice.m
@@ -13,12 +13,12 @@
 
 @implementation HFFileByteSlice
 
-- initWithFile:(HFFileReference *)file {
+- (id)initWithFile:(HFFileReference *)file {
     REQUIRE_NOT_NULL(file);
     return [self initWithFile:file offset:0 length:[file length]];
 }
 
-- initWithFile:(HFFileReference *)file offset:(unsigned long long)off length:(unsigned long long)len {
+- (id)initWithFile:(HFFileReference *)file offset:(unsigned long long)off length:(unsigned long long)len {
     HFASSERT(HFSum(off, len) <= [file length]);
     REQUIRE_NOT_NULL(file);
     self = [super init];

--- a/framework/sources/HFFileReference.h
+++ b/framework/sources/HFFileReference.h
@@ -33,10 +33,10 @@
 @property (readonly) BOOL isFixedLength;
 
 /*! Open a file for reading and writing at the given path.  The permissions mode of any newly created file is 0744.  Returns nil if the file could not be opened, in which case the error parameter (if not nil) will be set. */
-- initWritableWithPath:(NSString *)path error:(NSError **)error;
+- (id)initWritableWithPath:(NSString *)path error:(NSError **)error;
 
 /*! Open a file for reading only at the given path.  Returns nil if the file could not be opened, in which case the error parameter (if not nil) will be set. */
-- initWithPath:(NSString *)path error:(NSError **)error;
+- (id)initWithPath:(NSString *)path error:(NSError **)error;
 
 /*! Closes the file. */
 - (void)close;

--- a/framework/sources/HFFileReference.m
+++ b/framework/sources/HFFileReference.m
@@ -135,7 +135,7 @@ static BOOL returnFTruncateError(NSError **error) {
     return ref->device == device && ref->inode == inode;
 }
 
-+ allocWithZone:(NSZone *)zone {
++ (id)allocWithZone:(NSZone *)zone {
     if (self == [HFFileReference class]) {
         /* Default to HFConcreteFileReference */
         return [HFConcreteFileReference allocWithZone:zone];
@@ -155,7 +155,7 @@ static BOOL returnFTruncateError(NSError **error) {
     
 }
 
-- initWithPath:(NSString *)path error:(NSError **)error {
+- (id)initWithPath:(NSString *)path error:(NSError **)error {
     self = [super init];
     isWritable = NO;
     fileDescriptor = -1;
@@ -167,7 +167,7 @@ static BOOL returnFTruncateError(NSError **error) {
     return self;
 }
 
-- initWritableWithPath:(NSString *)path error:(NSError **)error{
+- (id)initWritableWithPath:(NSString *)path error:(NSError **)error{
     self = [super init];
     isWritable = YES;
     fileDescriptor = -1;
@@ -278,7 +278,7 @@ static BOOL returnFTruncateError(NSError **error) {
 			tempBuf = malloc(blockSize);
 			ssize_t result = pread(fileDescriptor, tempBuf, blockSize, pos - prePad);
 			if (result != (ssize_t)blockSize) {
-				[NSException raise:NSGenericException format:@"Read result: %d expected: %u error: %s", result, blockSize, strerror(errno)];
+				[NSException raise:NSGenericException format:@"Read result: %zd expected: %u error: %s", result, blockSize, strerror(errno)];
 			}
 			NSUInteger toCopy = blockSize - prePad;
 			if (toCopy > length)
@@ -294,7 +294,7 @@ static BOOL returnFTruncateError(NSError **error) {
 
     ssize_t result = pread(fileDescriptor, buff, length, pos);
     if (result != (long)length) {
-        [NSException raise:NSGenericException format:@"Read result: %d expected: %u error: %s", result, length, strerror(errno)];
+        [NSException raise:NSGenericException format:@"Read result: %zd expected: %lu error: %s", result, (unsigned long)length, strerror(errno)];
     }
 
 	if (lastBlockLen) {
@@ -302,7 +302,7 @@ static BOOL returnFTruncateError(NSError **error) {
 			tempBuf = malloc(blockSize);
 		result = pread(fileDescriptor, tempBuf, blockSize, pos + length);
 		if (result != (ssize_t)blockSize) {
-			[NSException raise:NSGenericException format:@"Read result: %d expected: %u error: %s", result, blockSize, strerror(errno)];
+			[NSException raise:NSGenericException format:@"Read result: %zd expected: %u error: %s", result, blockSize, strerror(errno)];
 		}
 		memcpy(buff + length, tempBuf, lastBlockLen);
 	}
@@ -330,7 +330,7 @@ static BOOL returnFTruncateError(NSError **error) {
 			tempBuf = malloc(blockSize);
 			ssize_t result = pread(fileDescriptor, tempBuf, blockSize, offset - prePad);
 			if (result != (ssize_t)blockSize) {
-				[NSException raise:NSGenericException format:@"Read result: %d expected: %u error: %s", result, blockSize, strerror(errno)];
+				[NSException raise:NSGenericException format:@"Read result: %zd expected: %u error: %s", result, blockSize, strerror(errno)];
 			}
 			NSUInteger toCopy = blockSize - prePad;
 			if (toCopy > length)
@@ -366,7 +366,7 @@ static BOOL returnFTruncateError(NSError **error) {
 
 		result = pread(fileDescriptor, tempBuf, blockSize, offset);
 		if (result != (ssize_t)blockSize) {
-			[NSException raise:NSGenericException format:@"Read result: %d expected: %u error: %s", result, blockSize, strerror(errno)];
+			[NSException raise:NSGenericException format:@"Read result: %zd expected: %u error: %s", result, blockSize, strerror(errno)];
 		}
 		memcpy(tempBuf, buff, lastBlockLen);
 

--- a/framework/sources/HFFullMemoryByteArray.m
+++ b/framework/sources/HFFullMemoryByteArray.m
@@ -13,7 +13,7 @@
 
 @implementation HFFullMemoryByteArray
 
-- init {
+- (id)init {
     self = [super init];
     data = [[NSMutableData alloc] init];
     return self;

--- a/framework/sources/HFFullMemoryByteSlice.h
+++ b/framework/sources/HFFullMemoryByteSlice.h
@@ -16,6 +16,6 @@
 }
 
 /*! Init with a given NSData, which is copied via the \c -copy message. */
-- initWithData:(NSData *)val;
+- (id)initWithData:(NSData *)val;
 
 @end

--- a/framework/sources/HFFullMemoryByteSlice.m
+++ b/framework/sources/HFFullMemoryByteSlice.m
@@ -10,7 +10,7 @@
 
 @implementation HFFullMemoryByteSlice
 
-- initWithData:(NSData *)val {
+- (id)initWithData:(NSData *)val {
     REQUIRE_NOT_NULL(val);
     self = [super init];
     data = [val copy];

--- a/framework/sources/HFFunctions.h
+++ b/framework/sources/HFFunctions.h
@@ -423,7 +423,7 @@ NSString *HFDescribeByteCount(unsigned long long count);
 /*! @brief An object wrapper for the HFRange type.
 
   A simple class responsible for holding an immutable HFRange as an object.  Methods that logically work on multiple HFRanges usually take or return arrays of HFRangeWrappers. */
-@interface HFRangeWrapper : NSObject {
+@interface HFRangeWrapper : NSObject <NSCopying> {
     @public
     HFRange range;
 }

--- a/framework/sources/HFFunctions.m
+++ b/framework/sources/HFFunctions.m
@@ -612,7 +612,7 @@ NSString *HFDescribeByteCountWithPrefixAndSuffix(const char *stringPrefix, unsig
     else remainderBuff[0] = 0;
     
     char* resultPointer = NULL;
-    int numChars = asprintf(&resultPointer, "%s%llu%s %s%s%s", stringPrefix, dividend, remainderBuff, suffixes[i].suffix, "s" + !needsPlural, stringSuffix);
+    int numChars = asprintf(&resultPointer, "%s%llu%s %s%s%s", stringPrefix, dividend, remainderBuff, suffixes[i].suffix, needsPlural ? "s" : "", stringSuffix);
     if (numChars < 0) return NULL;
     return [[[NSString alloc] initWithBytesNoCopy:resultPointer length:numChars encoding:NSASCIIStringEncoding freeWhenDone:YES] autorelease];
 }

--- a/framework/sources/HFLayoutRepresenter.m
+++ b/framework/sources/HFLayoutRepresenter.m
@@ -256,7 +256,7 @@ static NSInteger sortByLayoutPosition(id a, id b, void *self) {
     return representers ? [NSArray arrayWithArray:representers] : [NSArray array];
 }
 
-- init {
+- (id)init {
     self = [super init];
     maximizesBytesPerLine = YES;
     return self;

--- a/framework/sources/HFObjectGraph.m
+++ b/framework/sources/HFObjectGraph.m
@@ -10,7 +10,7 @@
 
 @implementation HFObjectGraph
 
-- init {
+- (id)init {
     self = [super init];
     graph = (__strong CFMutableDictionaryRef)CFMakeCollectable(CFDictionaryCreateMutable(NULL, 0, NULL, &kCFTypeDictionaryValueCallBacks));
     containedObjects = [[NSMutableArray alloc] init]; //containedObjects is necessary to make sure that our key objects are strongly referenced, since we use a NULL-callback dictionary

--- a/framework/sources/HFPasteboardOwner.h
+++ b/framework/sources/HFPasteboardOwner.h
@@ -27,7 +27,7 @@ extern NSString *const HFPrivateByteArrayPboardType;
 }
 
 /* Creates an HFPasteboardOwner to own the given pasteboard with the given types.  Note that the NSPasteboard retains its owner. */
-+ ownPasteboard:(NSPasteboard *)pboard forByteArray:(HFByteArray *)array withTypes:(NSArray *)types;
++ (id)ownPasteboard:(NSPasteboard *)pboard forByteArray:(HFByteArray *)array withTypes:(NSArray *)types;
 - (HFByteArray *)byteArray;
 
 /* Performs a copy to pasteboard with progress reporting. This must be overridden if you support types other than the private pboard type. */

--- a/framework/sources/HFPasteboardOwner.m
+++ b/framework/sources/HFPasteboardOwner.m
@@ -21,7 +21,7 @@ NSString *const HFPrivateByteArrayPboardType = @"HFPrivateByteArrayPboardType";
     }
 }
 
-- initWithPasteboard:(NSPasteboard *)pboard forByteArray:(HFByteArray *)array withTypes:(NSArray *)types {
+- (id)initWithPasteboard:(NSPasteboard *)pboard forByteArray:(HFByteArray *)array withTypes:(NSArray *)types {
     REQUIRE_NOT_NULL(pboard);
     REQUIRE_NOT_NULL(array);
     REQUIRE_NOT_NULL(types);
@@ -36,7 +36,7 @@ NSString *const HFPrivateByteArrayPboardType = @"HFPrivateByteArrayPboardType";
     return self;
 }
 
-+ ownPasteboard:(NSPasteboard *)pboard forByteArray:(HFByteArray *)array withTypes:(NSArray *)types {
++ (id)ownPasteboard:(NSPasteboard *)pboard forByteArray:(HFByteArray *)array withTypes:(NSArray *)types {
     return [[[self alloc] initWithPasteboard:pboard forByteArray:array withTypes:types] autorelease];
 }
 

--- a/framework/sources/HFRepresenter.m
+++ b/framework/sources/HFRepresenter.m
@@ -25,7 +25,7 @@
     
 }
 
-- init {
+- (id)init {
     self = [super init];
     [self setLayoutPosition:[[self class] defaultLayoutPosition]];
     return self;

--- a/framework/sources/HFRepresenterHexTextView.m
+++ b/framework/sources/HFRepresenterHexTextView.m
@@ -21,12 +21,11 @@
     /* We'll calculate the max glyph advancement as we go.  If this is a bottleneck, we can use the bulk getAdvancements:... method */
     glyphAdvancement = 0;
 
-    NSUInteger nybbleValue;
-    for (nybbleValue=0; nybbleValue <= 0xF; nybbleValue++) {
+    for (short nybbleValue=0; nybbleValue <= 0xF; nybbleValue++) {
         NSString *string;
         NSGlyph glyphs[GLYPH_BUFFER_SIZE];
         NSUInteger glyphCount;
-        string = [[NSString alloc] initWithFormat:@"%lX", nybbleValue];
+        string = [[NSString alloc] initWithFormat:@"%hX", nybbleValue];
         [[storage mutableString] setString:string];
         [storage addAttribute:NSFontAttributeName value:font range:NSMakeRange(0, 1)];
         [string release];

--- a/framework/sources/HFRepresenterTextView.h
+++ b/framework/sources/HFRepresenterTextView.h
@@ -57,7 +57,7 @@
     } _hftvflags;
 }
 
-- initWithRepresenter:(HFTextRepresenter *)rep;
+- (id)initWithRepresenter:(HFTextRepresenter *)rep;
 - (void)clearRepresenter;
 
 - (HFTextRepresenter *)representer;

--- a/framework/sources/HFRepresenterTextView.m
+++ b/framework/sources/HFRepresenterTextView.m
@@ -616,7 +616,7 @@ enum LineCoverage_t {
     return result;
 }
 
-- initWithRepresenter:(HFTextRepresenter *)rep {
+- (id)initWithRepresenter:(HFTextRepresenter *)rep {
     self = [super initWithFrame:NSMakeRect(0, 0, 1, 1)];
     horizontalContainerInset = 4;
     representer = rep;
@@ -1492,7 +1492,7 @@ static size_t unionAndCleanLists(NSRect *rectList, id *valueList, size_t count) 
             NSUInteger bookmark = [newKey unsignedIntegerValue];
             callout = [[HFRepresenterTextViewCallout alloc] init];
             [callout setColor:[self colorForBookmark:bookmark]];
-            [callout setLabel:[NSString stringWithFormat:@"%lu", [newKey unsignedIntegerValue]]];
+            [callout setLabel:[NSString stringWithFormat:@"%lu", (unsigned long)[newKey unsignedIntegerValue]]];
             [callout setRepresentedObject:newKey];
             [callouts setObject:callout forKey:newKey];
             [callout release];

--- a/framework/sources/HFSharedMemoryByteSlice.m
+++ b/framework/sources/HFSharedMemoryByteSlice.m
@@ -14,7 +14,7 @@
 
 @implementation HFSharedMemoryByteSlice
 
-- initWithUnsharedData:(NSData *)unsharedData {
+- (id)initWithUnsharedData:(NSData *)unsharedData {
     self = [super init];
     REQUIRE_NOT_NULL(unsharedData);
     NSUInteger dataLength = [unsharedData length];
@@ -33,12 +33,12 @@
 }
 
 // retains, does not copy
-- initWithData:(NSMutableData *)dat {
+- (id)initWithData:(NSMutableData *)dat {
     REQUIRE_NOT_NULL(dat);
     return [self initWithData:dat offset:0 length:[dat length]];
 }
 
-- initWithData:(NSMutableData *)dat offset:(NSUInteger)off length:(NSUInteger)len {
+- (id)initWithData:(NSMutableData *)dat offset:(NSUInteger)off length:(NSUInteger)len {
     self = [super init];
     REQUIRE_NOT_NULL(dat);
     HFASSERT(off + len >= off); //check for overflow
@@ -49,7 +49,7 @@
     return self;
 }
 
-- initWithSharedData:(NSMutableData *)dat offset:(NSUInteger)off length:(NSUInteger)len tail:(const void *)tail tailLength:(NSUInteger)tailLen {
+- (id)initWithSharedData:(NSMutableData *)dat offset:(NSUInteger)off length:(NSUInteger)len tail:(const void *)tail tailLength:(NSUInteger)tailLen {
     self = [super init];
     if (off || len) REQUIRE_NOT_NULL(dat);
     if (tailLen) REQUIRE_NOT_NULL(tail);
@@ -131,7 +131,7 @@
     return result;
 }
 
-- byteSliceByAppendingSlice:(HFByteSlice *)slice {
+- (HFByteSlice *)byteSliceByAppendingSlice:(HFByteSlice *)slice {
     REQUIRE_NOT_NULL(slice);
     const unsigned long long sliceLength = [slice length];
     if (sliceLength == 0) return self;

--- a/framework/sources/HFStatusBarRepresenter.m
+++ b/framework/sources/HFStatusBarRepresenter.m
@@ -35,7 +35,7 @@
     [cell setBackgroundStyle:NSBackgroundStyleRaised];
 }
 
-- initWithFrame:(NSRect)frame {
+- (id)initWithFrame:(NSRect)frame {
     self = [super initWithFrame:frame];
     [self _sharedInitStatusBarView];
     return self;


### PR DESCRIPTION
Proper string formatting for size_t, NSInteger, etc.
Added implicit (id)s, etc.
Bumped target to 10.7 because XIB labels require it apparently (according to the warnings).
