### PR TITLE
Add inspector types for SLEB128 and ULEB128 ints

### DIFF
--- a/app/resources/DataInspectorView.xib
+++ b/app/resources/DataInspectorView.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">13E28</string>
-		<string key="IBDocument.InterfaceBuilderVersion">5056</string>
-		<string key="IBDocument.AppKitVersion">1265.21</string>
-		<string key="IBDocument.HIToolboxVersion">698.00</string>
+		<string key="IBDocument.SystemVersion">14B25</string>
+		<string key="IBDocument.InterfaceBuilderVersion">6724</string>
+		<string key="IBDocument.AppKitVersion">1343.16</string>
+		<string key="IBDocument.HIToolboxVersion">755.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">5056</string>
+			<string key="NS.object.0">6724</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>NSButtonCell</string>
@@ -40,7 +40,7 @@
 				<string key="NSClassName">NSApplication</string>
 			</object>
 			<object class="NSScrollView" id="878556809">
-				<reference key="NSNextResponder"/>
+				<nil key="NSNextResponder"/>
 				<int key="NSvFlags">258</int>
 				<array class="NSMutableArray" key="NSSubviews">
 					<object class="NSClipView" id="676704582">
@@ -52,7 +52,6 @@
 								<int key="NSvFlags">256</int>
 								<string key="NSFrameSize">{563, 20}</string>
 								<reference key="NSSuperview" ref="676704582"/>
-								<reference key="NSWindow"/>
 								<bool key="NSEnabled">YES</bool>
 								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<bool key="NSControlAllowsExpansionToolTips">YES</bool>
@@ -72,7 +71,7 @@
 											<int key="NSCellFlags2">2048</int>
 											<string key="NSContents"/>
 											<object class="NSFont" key="NSSupport" id="26">
-												<string key="NSName">.LucidaGrandeUI</string>
+												<bool key="IBIsSystemFont">YES</bool>
 												<double key="NSSize">11</double>
 												<int key="NSfFlags">3100</int>
 											</object>
@@ -158,6 +157,26 @@
 														<string key="NSAction">_popUpItemAction:</string>
 														<reference key="NSTarget" ref="655676489"/>
 													</object>
+													<object class="NSMenuItem" id="691974419">
+														<reference key="NSMenu" ref="228732529"/>
+														<string key="NSTitle">SLEB128</string>
+														<string key="NSKeyEquiv"/>
+														<int key="NSMnemonicLoc">2147483647</int>
+														<reference key="NSOnImage" ref="22788290"/>
+														<reference key="NSMixedImage" ref="68430916"/>
+														<string key="NSAction">_popUpItemAction:</string>
+														<reference key="NSTarget" ref="655676489"/>
+													</object>
+													<object class="NSMenuItem" id="550566126">
+														<reference key="NSMenu" ref="228732529"/>
+														<string key="NSTitle">ULEB128</string>
+														<string key="NSKeyEquiv"/>
+														<int key="NSMnemonicLoc">2147483647</int>
+														<reference key="NSOnImage" ref="22788290"/>
+														<reference key="NSMixedImage" ref="68430916"/>
+														<string key="NSAction">_popUpItemAction:</string>
+														<reference key="NSTarget" ref="655676489"/>
+													</object>
 												</array>
 											</object>
 											<int key="NSSelectedIndex">-1</int>
@@ -204,22 +223,23 @@
 											<string key="NSKeyEquivalent"/>
 											<int key="NSPeriodicDelay">400</int>
 											<int key="NSPeriodicInterval">75</int>
-											<nil key="NSMenuItem"/>
+											<object class="NSMenuItem" key="NSMenuItem" id="116454093">
+												<reference key="NSMenu" ref="589005787"/>
+												<string key="NSTitle">little</string>
+												<string key="NSKeyEquiv"/>
+												<int key="NSKeyEquivModMask">1048576</int>
+												<int key="NSMnemonicLoc">2147483647</int>
+												<int key="NSState">1</int>
+												<reference key="NSOnImage" ref="22788290"/>
+												<reference key="NSMixedImage" ref="68430916"/>
+												<string key="NSAction">_popUpItemAction:</string>
+												<reference key="NSTarget" ref="300317781"/>
+											</object>
 											<bool key="NSMenuItemRespectAlignment">YES</bool>
 											<object class="NSMenu" key="NSMenu" id="589005787">
 												<string key="NSTitle">OtherViews</string>
 												<array class="NSMutableArray" key="NSMenuItems">
-													<object class="NSMenuItem" id="116454093">
-														<reference key="NSMenu" ref="589005787"/>
-														<string key="NSTitle">little</string>
-														<string key="NSKeyEquiv"/>
-														<int key="NSKeyEquivModMask">1048576</int>
-														<int key="NSMnemonicLoc">2147483647</int>
-														<reference key="NSOnImage" ref="22788290"/>
-														<reference key="NSMixedImage" ref="68430916"/>
-														<string key="NSAction">_popUpItemAction:</string>
-														<reference key="NSTarget" ref="300317781"/>
-													</object>
+													<reference ref="116454093"/>
 													<object class="NSMenuItem" id="369676711">
 														<reference key="NSMenu" ref="589005787"/>
 														<string key="NSTitle">big</string>
@@ -373,7 +393,6 @@
 						</array>
 						<string key="NSFrame">{{2, 2}, {563, 20}}</string>
 						<reference key="NSSuperview" ref="878556809"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="531543764"/>
 						<reference key="NSDocView" ref="531543764"/>
 						<object class="NSColor" key="NSBGColor">
@@ -383,14 +402,17 @@
 							<reference key="NSColor" ref="486459038"/>
 						</object>
 						<int key="NScvFlags">4</int>
+						<bool key="NSAutomaticallyAdjustsContentInsets">YES</bool>
 					</object>
 					<object class="NSScroller" id="810613641">
 						<reference key="NSNextResponder" ref="878556809"/>
 						<int key="NSvFlags">-2147483392</int>
 						<string key="NSFrame">{{-100, -100}, {485, 15}}</string>
 						<reference key="NSSuperview" ref="878556809"/>
-						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="1002858633"/>
 						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						<string key="NSControlAction">_doScroller:</string>
+						<reference key="NSControlTarget" ref="878556809"/>
 						<int key="NSsFlags">1</int>
 						<reference key="NSTarget" ref="878556809"/>
 						<string key="NSAction">_doScroller:</string>
@@ -400,16 +422,16 @@
 						<int key="NSvFlags">-2147483392</int>
 						<string key="NSFrame">{{-100, -100}, {15, 61}}</string>
 						<reference key="NSSuperview" ref="878556809"/>
-						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="676704582"/>
 						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						<string key="NSControlAction">_doScroller:</string>
+						<reference key="NSControlTarget" ref="878556809"/>
 						<reference key="NSTarget" ref="878556809"/>
 						<string key="NSAction">_doScroller:</string>
 					</object>
 				</array>
 				<string key="NSFrameSize">{567, 24}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="676704582"/>
+				<reference key="NSNextKeyView" ref="810613641"/>
 				<int key="NSsFlags">133123</int>
 				<reference key="NSVScroller" ref="1002858633"/>
 				<reference key="NSHScroller" ref="810613641"/>
@@ -422,7 +444,7 @@
 		</array>
 		<object class="IBObjectContainer" key="IBDocument.Objects">
 			<bool key="usesAutoincrementingIDs">NO</bool>
-			<array class="NSMutableArray" key="connectionRecords">
+			<array key="connectionRecords">
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
 						<string key="label">outletView</string>
@@ -586,6 +608,8 @@
 							<reference ref="911876770"/>
 							<reference ref="961463389"/>
 							<reference ref="537569512"/>
+							<reference ref="550566126"/>
+							<reference ref="691974419"/>
 						</array>
 						<reference key="parent" ref="655676489"/>
 					</object>
@@ -651,6 +675,16 @@
 						<reference key="object" ref="940652927"/>
 						<reference key="parent" ref="886357013"/>
 					</object>
+					<object class="IBObjectRecord">
+						<string key="id">glG-XB-fsS</string>
+						<reference key="object" ref="550566126"/>
+						<reference key="parent" ref="228732529"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">Zh9-Vv-mpr</string>
+						<reference key="object" ref="691974419"/>
+						<reference key="parent" ref="228732529"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -715,96 +749,20 @@
 				<boolean value="NO" key="93.showNotes"/>
 				<string key="94.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<boolean value="NO" key="94.showNotes"/>
+				<string key="Zh9-Vv-mpr.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<boolean value="NO" key="Zh9-Vv-mpr.showNotes"/>
+				<string key="glG-XB-fsS.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<boolean value="NO" key="glG-XB-fsS.showNotes"/>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">DataInspectorPlusMinusButtonCell</string>
-					<string key="superclassName">NSButtonCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/DataInspectorPlusMinusButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">DataInspectorRepresenter</string>
-					<string key="superclassName">HFRepresenter</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="addRow:">id</string>
-						<string key="doubleClickedTable:">id</string>
-						<string key="removeRow:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="addRow:">
-							<string key="name">addRow:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="doubleClickedTable:">
-							<string key="name">doubleClickedTable:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="removeRow:">
-							<string key="name">removeRow:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="outletView">NSView</string>
-						<string key="table">NSTableView</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="outletView">
-							<string key="name">outletView</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="table">
-							<string key="name">table</string>
-							<string key="candidateClassName">NSTableView</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/DataInspectorRepresenter.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">DataInspectorScrollView</string>
-					<string key="superclassName">NSScrollView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/DataInspectorScrollView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">DataInspectorTableView</string>
-					<string key="superclassName">NSTableView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/DataInspectorTableView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">HFRepresenter</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/HFRepresenter.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes"/>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
 		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">YES</bool>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1070" key="NS.object.0"/>
-		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
 			<integer value="4600" key="NS.object.0"/>
@@ -812,8 +770,8 @@
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
 		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NSMenuCheckmark">{11, 11}</string>
-			<string key="NSMenuMixedState">{10, 3}</string>
+			<string key="NSMenuCheckmark">{12, 12}</string>
+			<string key="NSMenuMixedState">{10, 2}</string>
 		</dictionary>
 	</data>
 </archive>


### PR DESCRIPTION
This adds support for viewing data as SLEB128 or ULEB128 encoded integers. These are used in DWARF debug info, compact-unwind information, and the 'modern' dyld info inside of Mach-O files.
