### PR TITLE
Ignoring deprecation warning for OSAtomicIncrementXXX methods.

### DIFF
--- a/framework/sources/HFFunctions.h
+++ b/framework/sources/HFFunctions.h
@@ -327,6 +327,8 @@ static inline CGFloat HFCopysign(CGFloat a, CGFloat b) {
 #endif
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 /*! Atomically increments an NSUInteger, returning the new value.  Optionally invokes a memory barrier. */
 static inline NSUInteger HFAtomicIncrement(volatile NSUInteger *ptr, BOOL barrier) {
     return _Generic(ptr,
@@ -350,6 +352,7 @@ static inline NSUInteger HFAtomicDecrement(volatile NSUInteger *ptr, BOOL barrie
 #endif
         volatile unsigned long long *: (barrier ? OSAtomicDecrement64Barrier : OSAtomicDecrement64)((volatile int64_t *)ptr));
 }
+#pragma clang diagnostic pop
 
 /*! Converts a long double to unsigned long long.  Assumes that val is already an integer - use floorl or ceill */
 static inline unsigned long long HFFPToUL(long double val) {


### PR DESCRIPTION
The macOS 10.12 SDK deprecated the OSAtomicIncrementXXX methods. For now, I wrapped the calls with #pragma clang diagnostic ignored. A better fix would be to use the methods in stdatomic.h, but I didn't want to make a change like that without understanding the code better.