### PR TITLE
Always display the last visible line number

### DIFF
--- a/framework/sources/HFLineCountingView.m
+++ b/framework/sources/HFLineCountingView.m
@@ -493,7 +493,7 @@ static inline int common_prefix_length(const char *a, const char *b) {
     NSRect textRect = self.bounds;
     textRect.size.width -= 5;
     textRect.origin.y -= verticalOffset;
-    textRect.size.height += verticalOffset;
+    textRect.size.height += verticalOffset + _lineHeight;
     
     if (! textAttributes) {
         NSMutableParagraphStyle *mutableStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/10537578/23073723/bb49b48c-f536-11e6-9a8c-397a968d269f.png)
After:
![after](https://cloud.githubusercontent.com/assets/10537578/23074829/7b104c38-f53a-11e6-98f6-59a89c1dbdf0.png)

This bug is not visible when using a font that triggers rendering path 1 (namely, Monaco, Courier and Consolas).
Basically, the problem is that -[NSString drawInRect:withAttributes:] clips every line that does not fit *entirely* in the given NSRect.