### PR TITLE
Fix #84

### DIFF
--- a/framework/sources/HFRepresenterTextView.m
+++ b/framework/sources/HFRepresenterTextView.m
@@ -431,7 +431,7 @@ enum LineCoverage_t {
         [[self window] removeChildWindow:pulseWindow];
         [pulseWindow setFrame:pulseWindowBaseFrameInScreenCoordinates display:YES animate:NO];
         [NSTimer scheduledTimerWithTimeInterval:1. / 30. target:self selector:@selector(fadePulseWindowTimer:) userInfo:pulseWindow repeats:YES];
-        //release is not necessary, since it relases when closed by default
+        //The window is now owned by the timer, and will be relased when it is invalidated
         pulseWindow = nil;
         pulseWindowBaseFrameInScreenCoordinates = NSZeroRect;
     }
@@ -472,6 +472,7 @@ enum LineCoverage_t {
                 pulseWindowBaseFrameInScreenCoordinates.origin = [[self window] convertRectToScreen:pulseWindowBaseFrameInScreenCoordinates].origin;
                 
                 pulseWindow = [[NSWindow alloc] initWithContentRect:pulseWindowBaseFrameInScreenCoordinates styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO];
+                [pulseWindow setReleasedWhenClosed:NO];
                 [pulseWindow setOpaque:NO];
                 HFTextSelectionPulseView *pulseView = [[HFTextSelectionPulseView alloc] initWithFrame:[[pulseWindow contentView] frame]];
                 [pulseWindow setContentView:pulseView];


### PR DESCRIPTION
I don't know if this is the same crash as #83 because there's no crash log to look at, but #84 is related to a bug in the code that handles the yellow "pulse window" that appears after a search.

More specifically, in -[HFRepresenterTextView fadePulseWindowTimer:], a call to -[NSWindow close] over-releases the pulse window by 1. I fixed the crash by simply setting the window to not be released on close.

Originally the crash did not happen because, as the comment in the code says, the retain implicitly done when creating the window was meant to be balanced by the implicit release in that very same -[NSWindow close] call, but ARC does not understand that and it blindly releases the window as soon as the pulseWindow ivar is set to nil. At that point, the reference count of the window is 1 (because NSTimer retains its userInfo), but it will be released both by -[NSWindow close] and by the NSTimer.