### PR TITLE
Implement window frame autosave

### DIFF
--- a/English.lproj/MyDocument.xib
+++ b/English.lproj/MyDocument.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12118"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="BaseDataDocument">
@@ -12,7 +13,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" tabbingMode="disallowed" id="5" userLabel="Window" customClass="DocumentWindow">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="DocumentWindow" animationBehavior="default" tabbingMode="disallowed" id="5" userLabel="Window" customClass="DocumentWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/app/resources/DataInspectorView.xib
+++ b/app/resources/DataInspectorView.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12118"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="DataInspectorRepresenter">
@@ -90,7 +91,7 @@
                                 </popUpButtonCell>
                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                             </tableColumn>
-                            <tableColumn identifier="inspected_value" width="355" minWidth="40" maxWidth="10000" id="62">
+                            <tableColumn identifier="inspected_value" width="375" minWidth="40" maxWidth="10000" id="62">
                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>

--- a/app/sources/BaseDataDocument.h
+++ b/app/sources/BaseDataDocument.h
@@ -12,7 +12,7 @@
 
 extern NSString * const BaseDataDocumentDidChangeStringEncodingNotification;
 
-@interface BaseDataDocument : NSDocument <NSWindowDelegate, DragDropDelegate> {
+@interface BaseDataDocument : NSDocument <DocumentWindowDelegate, DragDropDelegate> {
     IBOutlet NSSplitView *containerView;
     HFController *controller;
     

--- a/app/sources/BaseDataDocument.m
+++ b/app/sources/BaseDataDocument.m
@@ -329,7 +329,8 @@ static inline Class preferredByteArrayClass(void) {
 }
 
 - (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize {
-    if (sender != [self window] || layoutRepresenter == nil) return frameSize;
+    USE(sender);
+    if (layoutRepresenter == nil) return frameSize;
     return [self minimumWindowFrameSizeForProposedSize:frameSize];
 }
 
@@ -359,6 +360,9 @@ static inline Class preferredByteArrayClass(void) {
 
 /* Shared point for setting up a window, optionally setting a bytes per line */
 - (void)setupWindowEnforcingBytesPerLine:(NSUInteger)bplOrZero {
+
+    layoutRepresenter = [[HFLayoutRepresenter alloc] init];
+    [controller addRepresenter:layoutRepresenter];
     
     NSView *layoutView = [layoutRepresenter view];
     [layoutView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
@@ -488,10 +492,11 @@ static inline Class preferredByteArrayClass(void) {
     hexRepresenter = [[HFHexTextRepresenter alloc] init];
     asciiRepresenter = [[HFStringEncodingTextRepresenter alloc] init];
     scrollRepresenter = [[HFVerticalScrollerRepresenter alloc] init];
-    layoutRepresenter = [[HFLayoutRepresenter alloc] init];
     statusBarRepresenter = [[HFStatusBarRepresenter alloc] init];
     dataInspectorRepresenter = [[DataInspectorRepresenter alloc] init];
     textDividerRepresenter = [[TextDividerRepresenter alloc] init];
+    /* We will create layoutRepresenter when the window is actually shown
+     * so that it will never exist in an inconsistent state */
     
     [(NSView *)[hexRepresenter view] setAutoresizingMask:NSViewHeightSizable];
     [(NSView *)[asciiRepresenter view] setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
@@ -513,7 +518,6 @@ static inline Class preferredByteArrayClass(void) {
     [controller setShouldLiveReload:[defs boolForKey:@"LiveReload"]];
     [controller setUndoManager:[self undoManager]];
     [controller setBytesPerColumn:[defs integerForKey:@"BytesPerColumn"]];
-    [controller addRepresenter:layoutRepresenter];
     
     [self setShouldLiveReload:[controller shouldLiveReload]];
     

--- a/app/sources/BaseDataDocument.m
+++ b/app/sources/BaseDataDocument.m
@@ -334,6 +334,13 @@ static inline Class preferredByteArrayClass(void) {
     return [self minimumWindowFrameSizeForProposedSize:frameSize];
 }
 
+- (void)window:(NSWindow *)w didSaveFrameWithName:(NSString *)name {
+    USE(w);
+    USE(name);
+    NSInteger bpl = [controller bytesPerLine];
+    [[NSUserDefaults standardUserDefaults] setInteger:bpl forKey:@"BytesPerLine"];
+}
+
 /* Relayout the window without increasing its window frame size */
 - (void)relayoutAndResizeWindowPreservingFrame {
     NSWindow *window = [self window];
@@ -383,7 +390,13 @@ static inline Class preferredByteArrayClass(void) {
         [self relayoutAndResizeWindowForBytesPerLine:bplOrZero];
     } else {
         /* Here we probably get smaller */
-        [self relayoutAndResizeWindowPreservingFrame];
+        NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+        NSNumber *bpl = [ud objectForKey:@"BytesPerLine"];
+        if (!bpl || ![bpl isKindOfClass:[NSNumber class]]) {
+            [self relayoutAndResizeWindowPreservingFrame];
+        } else {
+            [self relayoutAndResizeWindowForBytesPerLine:bpl.integerValue];
+        }
     }
 }
 

--- a/app/sources/DocumentWindow.h
+++ b/app/sources/DocumentWindow.h
@@ -12,6 +12,11 @@
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender;
 @end
 
+@protocol DocumentWindowDelegate <NSWindowDelegate>
+@optional
+- (void)window:(NSWindow *)w didSaveFrameWithName:(NSString *)name;
+@end
+
 @interface DocumentWindow : NSWindow
-@property (assign) id<NSWindowDelegate, DragDropDelegate>delegate;
+@property (assign) id<DocumentWindowDelegate, DragDropDelegate>delegate;
 @end

--- a/app/sources/DocumentWindow.m
+++ b/app/sources/DocumentWindow.m
@@ -25,4 +25,10 @@
     return [self.delegate performDragOperation:sender];
 }
 
+- (void)saveFrameUsingName:(NSString *)name {
+    [super saveFrameUsingName:name];
+    if ([self.delegate respondsToSelector:@selector(window:didSaveFrameWithName:)])
+        [self.delegate window:self didSaveFrameWithName:name];
+}
+
 @end


### PR DESCRIPTION
This PR enables window frame autosave for the main document window of HexFiend.

The main use-case is to allow customising the default number of bytes per line. Since the width of the line number sidebar depends on the size of the file, saving the window width is not enough to reliably restore the number of bytes per line. Thus, I had to explicitly implement saving the number of bytes per line.

A hex editor works best when the number of bytes per line is a multiple of 4, for various reasons that are fairly well known. The most common default in other hex editors is 16 bytes per line. But, with the default font (Monaco 10pt) in HexFiend the default window size for an empty file shows 15 bytes per line. If one wants to change the font size it becomes even less than that, because the default window size is also kinda small. And resizing the window each time is quite a drag...

With this change one can resize the window once, and be done with it forever.