### PR TITLE
hexf: add a shebang

### DIFF
--- a/app/resources/hexf
+++ b/app/resources/hexf
@@ -1,3 +1,4 @@
+#!/bin/sh
 if [ -z "$1" ]; then
 	echo "Missing path"
 	exit 1


### PR DESCRIPTION
When trying out the new `hexf` tool from 2.6.0, I noticed it was missing a shebang.