### PR TITLE
Permit building with a default python 3

### DIFF
--- a/documentation_tools/build_documentation.py
+++ b/documentation_tools/build_documentation.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import sys, os, subprocess, distutils.spawn, shutil
 
 env = os.getenv
@@ -7,14 +9,14 @@ norm = os.path.normpath
 
 built_products_dir = env("BUILT_PRODUCTS_DIR")
 if built_products_dir == None:
-    print "Environmental variable BUILT_PRODUCTS_DIR is missing. This script should be run from within Xcode."
+    print ("Environmental variable BUILT_PRODUCTS_DIR is missing. This script should be run from within Xcode.")
     sys.exit(1)
 
 src_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 config_path= norm(src_root + "/documentation_tools/hexfiend_doxyfile.config")
 if not os.path.isfile(config_path):
-    print "Doxygen config file does not exist at " + config_path
+    print ("Doxygen config file does not exist at " + config_path)
     sys.exit(1)
 
 # Silently take advantage of MacPorts or Homebrew.
@@ -22,15 +24,15 @@ doxygen_search = os.pathsep.join((os.environ['PATH'],'/usr/local/bin','/opt/loca
 doxygen_path = os.getenv("DOXYGEN_PATH") or distutils.spawn.find_executable("doxygen", path=doxygen_search)
 if not doxygen_path or not os.path.isfile(doxygen_path):
     if os.getenv("DOXYGEN_PATH"):
-        print "Could not find doxygen at DOXYGEN_PATH=", doxygen_path
+        print ("Could not find doxygen at DOXYGEN_PATH=", doxygen_path)
     else:
-        print "Could not find doxygen: install doxygen to your PATH, or add a DOXYGEN_PATH"
+        print ("Could not find doxygen: install doxygen to your PATH, or add a DOXYGEN_PATH")
         sys.exit(1)
 
 # Headers should be a symlink, so get its real path
 headers = os.path.realpath(built_products_dir + "/HexFiend.framework/Headers")
 if not os.path.isdir(headers):
-    print "The HexFiend header directory does not exist at " + headers
+    print ("The HexFiend header directory does not exist at " + headers)
     sys.exit(1)
 
 output_dir = norm(os.path.join(src_root, 'docs'))
@@ -39,10 +41,10 @@ try:
 except:
     pass
 if not os.path.isdir(output_dir):
-    print "The documentation output directory does not exist at " + output_dir
+    print ("The documentation output directory does not exist at " + output_dir)
     sys.exit(1)
 
-print 'Documentation output: ' + output_dir
+print ('Documentation output: ' + output_dir)
 sys.stdout.flush()
 
 new_wd = norm(src_root + "/documentation_tools/")


### PR DESCRIPTION
This fixes build_documentation.py so that if `python` by default is
python 3 it will still work (but does not break python 2)