### PR TITLE
Add nullability annotations to the Framework

### DIFF
--- a/framework/sources/BTree/HFBTree.h
+++ b/framework/sources/BTree/HFBTree.h
@@ -6,6 +6,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef unsigned long long HFBTreeIndex;
 
 @class HFBTreeNode;
@@ -20,7 +22,7 @@ typedef unsigned long long HFBTreeIndex;
 }
 
 - (void)insertEntry:(id)entry atOffset:(HFBTreeIndex)offset;
-- (id)entryContainingOffset:(HFBTreeIndex)offset beginningOffset:(HFBTreeIndex *)outBeginningOffset;
+- (nullable id)entryContainingOffset:(HFBTreeIndex)offset beginningOffset:(HFBTreeIndex *)outBeginningOffset;
 - (void)removeEntryAtOffset:(HFBTreeIndex)offset;
 - (void)removeAllEntries;
 
@@ -29,12 +31,14 @@ typedef unsigned long long HFBTreeIndex;
 - (void)checkIntegrityOfBTreeStructure;
 #endif
 
-- (NSEnumerator *)entryEnumerator;
+- (nonnull NSEnumerator *)entryEnumerator;
 - (NSArray *)allEntries;
 
 - (HFBTreeIndex)length;
 
 /* Applies the given function to the entry at the given offset, continuing with subsequent entries until the function returns NO.  Do not modify the tree from within this function. */
-- (void)applyFunction:(BOOL (*)(id entry, HFBTreeIndex offset, void *userInfo))func toEntriesStartingAtOffset:(HFBTreeIndex)offset withUserInfo:(void *)userInfo;
+- (void)applyFunction:(BOOL (*)(id entry, HFBTreeIndex offset, void *_Nullable userInfo))func toEntriesStartingAtOffset:(HFBTreeIndex)offset withUserInfo:(void *_Nullable)userInfo;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFAnnotatedTree.h
+++ b/framework/sources/HFAnnotatedTree.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/NSObject.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef unsigned long long (*HFAnnotatedTreeAnnotaterFunction_t)(id left, id right);
 
 
@@ -55,3 +57,5 @@ typedef unsigned long long (*HFAnnotatedTreeAnnotaterFunction_t)(id left, id rig
 #endif
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFBTreeByteArray.h
+++ b/framework/sources/HFBTreeByteArray.h
@@ -8,6 +8,8 @@
 
 #import <HexFiend/HFByteArray.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFBTree;
 
 /*! @class HFBTreeByteArray
@@ -28,3 +30,5 @@ Create an HFBTreeByteArray via \c -init.  It has no methods other than those on 
 - (instancetype)init;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteArray.h
+++ b/framework/sources/HFByteArray.h
@@ -7,6 +7,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFByteSlice, HFProgressTracker, HFFileReference, HFByteRangeAttributeArray;
 
 typedef NS_ENUM(NSUInteger, HFByteArrayDataStringType) {
@@ -72,7 +74,7 @@ HFByteArray is an abstract class.  It will raise an exception if you attempt to 
 - (NSEnumerator *)byteSliceEnumerator;
 
 /*! Returns the byte slice containing the byte at the given index, and the actual offset of this slice. */
-- (HFByteSlice *)sliceContainingByteAtIndex:(unsigned long long)offset beginningOffset:(unsigned long long *)actualOffset;
+- (nullable HFByteSlice *)sliceContainingByteAtIndex:(unsigned long long)offset beginningOffset:(unsigned long long *_Nullable)actualOffset;
 //@}
 
 /*! @name Modifying the byte array
@@ -131,7 +133,7 @@ HFByteArray is an abstract class.  It will raise an exception if you attempt to 
     @param progressTracker An HFProgressTracker to allow progress reporting and cancelleation for the search operation.
     @return The index in the receiver of bytes equal to <tt>findBytes</tt>, or ULLONG_MAX if the byte array was not found (or the operation was cancelled)
 */
-- (unsigned long long)indexOfBytesEqualToBytes:(HFByteArray *)findBytes inRange:(HFRange)range searchingForwards:(BOOL)forwards trackingProgress:(HFProgressTracker *)progressTracker;
+- (unsigned long long)indexOfBytesEqualToBytes:(HFByteArray *)findBytes inRange:(HFRange)range searchingForwards:(BOOL)forwards trackingProgress:(nullable HFProgressTracker *)progressTracker;
 //@}
 
 @end
@@ -147,7 +149,7 @@ HFByteArray is an abstract class.  It will raise an exception if you attempt to 
    @param error An out NSError parameter.
    @return YES if the write succeeded, NO if it failed.
 */
-- (BOOL)writeToFile:(NSURL *)targetURL trackingProgress:(HFProgressTracker *)progressTracker error:(NSError **)error;
+- (BOOL)writeToFile:(NSURL *)targetURL trackingProgress:(nullable HFProgressTracker *)progressTracker error:(NSError **)error;
 
 /*! Returns the ranges of the file that would be modified, if the receiver were written to it.  This is useful (for example) in determining if the clipboard can be preserved after a save operation. This is a concrete method on HFByteArray.
    @param reference An HFFileReference to the file to be modified
@@ -161,7 +163,7 @@ HFByteArray is an abstract class.  It will raise an exception if you attempt to 
    @param hint A dictionary that can be used to improve the efficiency of the operation, by allowing multiple byte arrays to share the same state.  If you plan to call this method on multiple byte arrays, pass the first one an empty NSMutableDictionary, and pass the same dictionary to subsequent calls.
    @return A YES return indicates the operation was successful, and the receiver no longer contains byte slices that source data from any of the ranges of the given file (or never did).  A NO return indicates that breaking the dependencies would require too much memory, and so the receiver still depends on some of those ranges.
 */
-- (BOOL)clearDependenciesOnRanges:(NSArray *)ranges inFile:(HFFileReference *)reference hint:(NSMutableDictionary *)hint;
+- (BOOL)clearDependenciesOnRanges:(NSArray *)ranges inFile:(HFFileReference *)reference hint:(nullable NSMutableDictionary *)hint;
 
 @end
 
@@ -175,6 +177,8 @@ HFByteArray is an abstract class.  It will raise an exception if you attempt to 
 - (HFByteRangeAttributeArray *)attributesForBytesInRange:(HFRange)range;
 
 /*! Returns the HFByteArray level byte range attribute array. Default is to return nil. */
-- (HFByteRangeAttributeArray *)byteRangeAttributeArray;
+- (nullable HFByteRangeAttributeArray *)byteRangeAttributeArray;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteArrayEditScript.h
+++ b/framework/sources/HFByteArrayEditScript.h
@@ -8,6 +8,8 @@
 #import <Cocoa/Cocoa.h>
 #import <HexFiend/HFTYpes.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @class HFByteArrayEditScript
  @brief A class that represents an sequence of instructions for editing an @link HFByteArray @endlink.  
  
@@ -46,7 +48,7 @@ struct HFEditInstruction_t {
 }
 
 /*! Computes the edit script (differences) from src to dst.  This retains both src and dst, and if they are modified then the receiver will likely no longer function. You may optionally pass an HFProgressTracker for progress reporting and cancellation.  This returns nil if it was cancelled. */
-- (instancetype)initWithDifferenceFromSource:(HFByteArray *)src toDestination:(HFByteArray *)dst trackingProgress:(HFProgressTracker *)progressTracker;
+- (nullable instancetype)initWithDifferenceFromSource:(HFByteArray *)src toDestination:(HFByteArray *)dst trackingProgress:(nullable HFProgressTracker *)progressTracker;
 
 /*! Applies the receiver to an HFByteArray. */
 - (void)applyToByteArray:(HFByteArray *)byteArray;
@@ -58,3 +60,5 @@ struct HFEditInstruction_t {
 - (struct HFEditInstruction_t)instructionAtIndex:(NSUInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteArrayProxiedData.h
+++ b/framework/sources/HFByteArrayProxiedData.h
@@ -7,6 +7,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFByteArray;
 
 /*! @class HFByteArrayDataProxy
@@ -23,3 +25,5 @@
 - (instancetype)initWithByteArray:(HFByteArray *)array;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteArray_Internal.h
+++ b/framework/sources/HFByteArray_Internal.h
@@ -1,14 +1,18 @@
 #import <HexFiend/HFByteArray.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface HFByteArray (HFInternal)
 
 - (BOOL)_debugIsEqual:(HFByteArray *)val;
 - (BOOL)_debugIsEqualToData:(NSData *)val;
 
-- (unsigned long long)_byteSearchBoyerMoore:(HFByteArray *)findBytes inRange:(const HFRange)range forwards:(BOOL)forwards trackingProgress:(HFProgressTracker *)progressTracker;
-- (unsigned long long)_byteSearchRollingHash:(HFByteArray *)findBytes inRange:(const HFRange)range forwards:(BOOL)forwards trackingProgress:(HFProgressTracker *)progressTracker;
-- (unsigned long long)_byteSearchNaive:(HFByteArray *)findBytes inRange:(const HFRange)range forwards:(BOOL)forwards trackingProgress:(HFProgressTracker *)progressTracker;
+- (unsigned long long)_byteSearchBoyerMoore:(HFByteArray *)findBytes inRange:(const HFRange)range forwards:(BOOL)forwards trackingProgress:(nullable HFProgressTracker *)progressTracker;
+- (unsigned long long)_byteSearchRollingHash:(HFByteArray *)findBytes inRange:(const HFRange)range forwards:(BOOL)forwards trackingProgress:(nullable HFProgressTracker *)progressTracker;
+- (unsigned long long)_byteSearchNaive:(HFByteArray *)findBytes inRange:(const HFRange)range forwards:(BOOL)forwards trackingProgress:(nullable HFProgressTracker *)progressTracker;
 
-- (unsigned long long)_byteSearchSingle:(unsigned char)byte inRange:(const HFRange)range forwards:(BOOL)forwards trackingProgress:(HFProgressTracker *)progressTracker;
+- (unsigned long long)_byteSearchSingle:(unsigned char)byte inRange:(const HFRange)range forwards:(BOOL)forwards trackingProgress:(nullable HFProgressTracker *)progressTracker;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteRangeAttribute.h
+++ b/framework/sources/HFByteRangeAttribute.h
@@ -1,5 +1,7 @@
 #import <Foundation/NSString.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /* Attributes used to illustrate diffs. */
 extern NSString * const kHFAttributeDiffInsertion;
 
@@ -20,3 +22,5 @@ extern NSString *HFBookmarkAttributeFromBookmark(NSInteger bookmark);
 
 /* Given a bookmark string, return the bookmark index for it, or NSNotFound if the string does not represent a bookmark attribute. */
 extern NSInteger HFBookmarkFromBookmarkAttribute(NSString *bookmark);
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteRangeAttributeArray.h
+++ b/framework/sources/HFByteRangeAttributeArray.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @class HFByteRangeAttributeArray
     @brief A class that represents sets of attributes, attached to ranges of bytes.
 */
@@ -14,7 +16,7 @@
 }
 
 /*! Returns the set of attributes at the given index, and the length over which those attributes are valid (if not NULL). */
-- (NSSet *)attributesAtIndex:(unsigned long long)index length:(unsigned long long *)length;
+- (NSSet *)attributesAtIndex:(unsigned long long)index length:(unsigned long long *_Nullable)length;
 
 /*! Returns the set of attributes within the given range. */
 - (NSSet *)attributesInRange:(HFRange)range;
@@ -44,7 +46,7 @@
 - (void)byteRange:(HFRange)srcRange wasReplacedByBytesOfLength:(unsigned long long)replacementLength;
 
 /*! Transfer attributes in the given range from array, adding baseOffset to each attribute range. range is interpreted as a range in array. If validator is not NULL, then it is called for each attribute; a YES return allows it to be added and a NO return prevents it. */
-- (void)transferAttributesFromAttributeArray:(HFByteRangeAttributeArray *)array range:(HFRange)range baseOffset:(unsigned long long)baseOffset validator:(BOOL (^)(NSString *))allowTransfer;
+- (void)transferAttributesFromAttributeArray:(HFByteRangeAttributeArray *)array range:(HFRange)range baseOffset:(unsigned long long)baseOffset validator:(nullable BOOL (^)(NSString *))allowTransfer;
 
 @end
 
@@ -61,3 +63,5 @@
 }
 @end
 #endif
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteSlice.h
+++ b/framework/sources/HFByteSlice.h
@@ -7,6 +7,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFFileReference, HFByteRangeAttributeArray;
 
 /*! @class HFByteSlice
@@ -31,7 +33,7 @@ The two principal subclasses of HFByteSlice are HFSharedMemoryByteSlice and HFFi
 
 /*! Attempts to create a new byte slice by appending one byte slice to another.  This does not modify the receiver or the slice argument (after all, both are immutable).  This is provided as an optimization, and is allowed to return nil if the appending cannot be done efficiently.  The default implementation returns nil.
 */
-- (HFByteSlice *)byteSliceByAppendingSlice:(HFByteSlice *)slice;
+- (nullable HFByteSlice *)byteSliceByAppendingSlice:(HFByteSlice *)slice;
 
 /*! Returns YES if the receiver is sourced from a file.  The default implementation returns NO.  This is used to estimate cost when writing to a file.
 */
@@ -48,6 +50,8 @@ The two principal subclasses of HFByteSlice are HFSharedMemoryByteSlice and HFFi
 @interface HFByteSlice (HFAttributes)
 
 /*!  Returns the attributes for the bytes in the given range. */
-- (HFByteRangeAttributeArray *)attributesForBytesInRange:(HFRange)range;
+- (nullable HFByteRangeAttributeArray *)attributesForBytesInRange:(HFRange)range;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteSliceFileOperation.h
+++ b/framework/sources/HFByteSliceFileOperation.h
@@ -7,6 +7,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFByteSlice, HFFileReference, HFProgressTracker;
 
 typedef NS_ENUM(NSInteger, HFByteSliceWriteError) {
@@ -28,6 +30,8 @@ typedef NS_ENUM(NSInteger, HFByteSliceWriteError) {
 - (HFRange)targetRange;
 
 - (unsigned long long)costToWrite;
-- (HFByteSliceWriteError)writeToFile:(HFFileReference *)file trackingProgress:(HFProgressTracker *)progressTracker error:(NSError **)error;
+- (HFByteSliceWriteError)writeToFile:(HFFileReference *)file trackingProgress:(nullable HFProgressTracker *)progressTracker error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFByteSliceFileOperationQueueEntry.h
+++ b/framework/sources/HFByteSliceFileOperationQueueEntry.h
@@ -7,6 +7,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface HFByteSliceFileOperationQueueEntry : NSObject {
 	@public
@@ -35,3 +36,5 @@
 - (NSUInteger)suggestedAllocationLengthForMinimum:(NSUInteger)minimum maximum:(NSUInteger)maximum;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFController.h
+++ b/framework/sources/HFController.h
@@ -9,6 +9,8 @@
 
 #import <HexFiend/HFTypes.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @header HFController
     @abstract The HFController.h header contains the HFController class, which is a central class in Hex Fiend. 
 */
@@ -229,7 +231,7 @@ You create an HFController via <tt>[[HFController alloc] init]</tt>.  After that
 - (unsigned long long)maximumSelectionLocation;
 
 /*! Convenience method for creating a byte array containing all of the selected bytes.  If the selection has length 0, this returns an empty byte array. */
-- (HFByteArray *)byteArrayForSelectedContentsRanges;
+- (nullable HFByteArray *)byteArrayForSelectedContentsRanges;
 //@}
 
 /* Number of bytes used in each column for a text-style representer. */
@@ -265,7 +267,7 @@ You create an HFController via <tt>[[HFController alloc] init]</tt>.  After that
 
 /*! The undo manager. If no undo manager is set, then undo is not supported. By default the undo manager is nil.
 */
-@property (nonatomic, strong) NSUndoManager *undoManager;
+@property (nullable, nonatomic, strong) NSUndoManager *undoManager;
 
 /*! Whether the user can edit the document. */
 @property (nonatomic) BOOL editable;
@@ -291,7 +293,7 @@ You create an HFController via <tt>[[HFController alloc] init]</tt>.  After that
 //@{
 /*! Callback for a representer-initiated change to some property.  For example, if some property of a view changes that would cause the number of bytes per line to change, then the representer should call this method which will trigger the HFController to recompute the relevant properties. */
 
-- (void)representer:(HFRepresenter *)rep changedProperties:(HFControllerPropertyBits)properties;
+- (void)representer:(nullable HFRepresenter *)rep changedProperties:(HFControllerPropertyBits)properties;
 //@}
 
 /*! @name Mouse selection
@@ -416,3 +418,5 @@ extern NSString * const HFChangeInFileModifiedRangesKey; //!< A key in the HFPre
 extern NSString * const HFChangeInFileShouldCancelKey; //!< A key in the HFPrepareForChangeInFileNotification specifying an NSValue containing a pointer to a BOOL.  If set to YES, then someone was unable to prepare and the file should not be saved.  It's a good idea to check if this value points to YES; if so your notification handler does not have to do anything.
 extern NSString * const HFChangeInFileHintKey; //!< The hint parameter that you may pass to clearDependenciesOnRanges:inFile:hint:
 //@}
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFControllerCoalescedUndo.h
+++ b/framework/sources/HFControllerCoalescedUndo.h
@@ -8,6 +8,8 @@
 #import <Cocoa/Cocoa.h>
 #import <HexFiend/HFTypes.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFByteArray, HFFileReference;
 
 /* A class to track the following operation - replace the data within rangeToReplace with the replacementByteArray */
@@ -19,7 +21,7 @@
 }
 
 /* replacedData may be nil if it should be considered empty */
-- (instancetype)initWithReplacedData:(HFByteArray *)replacedData atAnchorLocation:(unsigned long long)anchor;
+- (instancetype)initWithReplacedData:(nullable HFByteArray *)replacedData atAnchorLocation:(unsigned long long)anchor;
 
 - (instancetype)initWithOverwrittenData:(HFByteArray *)overwrittenData atAnchorLocation:(unsigned long long)anchor;
 
@@ -32,11 +34,11 @@
 - (void)overwriteDataInRange:(HFRange)overwriteRange withByteArray:(HFByteArray *)array;
 
 - (HFRange)rangeToReplace;
-- (HFByteArray *)deletedData;
+- (nullable HFByteArray *)deletedData;
 
 - (HFControllerCoalescedUndo *)invertWithByteArray:(HFByteArray *)byteArray;
 
-- (BOOL)clearDependenciesOnRanges:(NSArray *)ranges inFile:(HFFileReference *)reference hint:(NSMutableDictionary *)hint;
+- (BOOL)clearDependenciesOnRanges:(NSArray *)ranges inFile:(HFFileReference *)reference hint:(nullable NSMutableDictionary *)hint;
 - (void)invalidate;
 
 @end
@@ -50,11 +52,13 @@
 
 - (instancetype)initForInsertingByteArrays:(NSArray *)arrays inRanges:(NSArray *)ranges withSelectionAction:(int)selectionAction;
 
-- (NSArray *)byteArrays;
-- (NSArray *)replacementRanges;
+- (nullable NSArray *)byteArrays;
+- (nullable NSArray *)replacementRanges;
 - (int)selectionAction;
 
-- (BOOL)clearDependenciesOnRanges:(NSArray *)ranges inFile:(HFFileReference *)reference hint:(NSMutableDictionary *)hint;
+- (BOOL)clearDependenciesOnRanges:(NSArray *)ranges inFile:(HFFileReference *)reference hint:(nullable NSMutableDictionary *)hint;
 - (void)invalidate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFFileByteSlice.h
+++ b/framework/sources/HFFileByteSlice.h
@@ -7,6 +7,8 @@
 
 #import <HexFiend/HFByteSlice.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFFileReference;
 
 /*! @class HFFileByteSlice
@@ -27,3 +29,5 @@
 - (instancetype)initWithFile:(HFFileReference *)file offset:(unsigned long long)offset length:(unsigned long long)length;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFFileReference.h
+++ b/framework/sources/HFFileReference.h
@@ -7,6 +7,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @class HFFileReference
     @brief A reference to an open file.
     
@@ -33,10 +35,10 @@
 @property (readonly) BOOL isFixedLength;
 
 /*! Open a file for reading and writing at the given path.  The permissions mode of any newly created file is 0644.  Returns nil if the file could not be opened, in which case the error parameter (if not nil) will be set. */
-- (instancetype)initWritableWithPath:(NSString *)path error:(NSError **)error;
+- (nullable instancetype)initWritableWithPath:(NSString *)path error:(NSError **)error;
 
 /*! Open a file for reading only at the given path.  Returns nil if the file could not be opened, in which case the error parameter (if not nil) will be set. */
-- (instancetype)initWithPath:(NSString *)path error:(NSError **)error;
+- (nullable instancetype)initWithPath:(NSString *)path error:(NSError **)error;
 
 /*! Closes the file. */
 - (void)close;
@@ -72,3 +74,5 @@
 */
 @interface HFConcreteFileReference : HFFileReference
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFFullMemoryByteSlice.h
+++ b/framework/sources/HFFullMemoryByteSlice.h
@@ -7,6 +7,8 @@
 
 #import <HexFiend/HFByteSlice.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @class HFFullMemoryByteSlice
 
     @brief A simple subclass of HFByteSlice that wraps an NSData.  For most uses, prefer HFSharedMemoryByteSlice.
@@ -19,3 +21,5 @@
 - (instancetype)initWithData:(NSData *)val;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFFunctions.h
+++ b/framework/sources/HFFunctions.h
@@ -3,6 +3,8 @@
 #import <HexFiend/HFTypes.h>
 #import <libkern/OSAtomic.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 #define HFDEFAULT_FONT (@"Monaco")
 #define HFDEFAULT_FONTSIZE ((CGFloat)10.)
 
@@ -526,3 +528,5 @@ NSString *HFDescribeByteCount(unsigned long long count);
 - (void)assertIntegrity;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFFunctions_Private.h
+++ b/framework/sources/HFFunctions_Private.h
@@ -1,5 +1,7 @@
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFController;
 
 static inline BOOL HFIsRunningOnMountainLionOrLater(void) {
@@ -31,18 +33,20 @@ static inline unsigned long long llmin(unsigned long long a, unsigned long long 
 }
 
 /* Returns an NSData from an NSString containing hexadecimal characters.  Characters that are not hexadecimal digits are silently skipped.  Returns by reference whether the last byte contains only one nybble, in which case it will be returned in the low 4 bits of the last byte. */
-__private_extern__ NSData *HFDataFromHexString(NSString *string, BOOL* isMissingLastNybble);
+__private_extern__ NSData *HFDataFromHexString(NSString *string, BOOL *_Nullable isMissingLastNybble);
 
 __private_extern__ NSString *HFHexStringFromData(NSData *data);
 
-__private_extern__ unsigned char *HFFastMemchr(const unsigned char *s, unsigned char c, size_t n);
+__private_extern__ unsigned char *_Nullable HFFastMemchr(const unsigned char *s, unsigned char c, size_t n);
 
 /* Modifies F_NOCACHE for a given file descriptor */
 __private_extern__ void HFSetFDShouldCache(int fd, BOOL shouldCache);
 
-__private_extern__ NSString *HFDescribeByteCountWithPrefixAndSuffix(const char *stringPrefix, unsigned long long count, const char *stringSuffix);
+__private_extern__ NSString *HFDescribeByteCountWithPrefixAndSuffix(const char *_Nullable stringPrefix, unsigned long long count, const char *_Nullable stringSuffix);
 
 /* Function for OSAtomicAdd64 that just does a non-atomic add on PowerPC.  This should not be used where atomicity is critical; an example where this is used is updating a progress bar. */
 static inline int64_t HFAtomicAdd64(int64_t a, volatile int64_t *b) {
     return OSAtomicAdd64(a, b);
 }
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFGlyphTrie.h
+++ b/framework/sources/HFGlyphTrie.h
@@ -2,6 +2,8 @@
 
 #import <ApplicationServices/ApplicationServices.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /* BranchFactor is in bits */
 #define kHFGlyphTrieBranchFactor 4
 #define kHFGlyphTrieBranchCount (1 << kHFGlyphTrieBranchFactor)
@@ -22,7 +24,7 @@ static inline BOOL HFGlyphEqualsGlyph(struct HFGlyph_t a, struct HFGlyph_t b) {
 }
 
 struct HFGlyphTrieBranch_t {
-    void *children[kHFGlyphTrieBranchCount];
+    void *_Nullable children[kHFGlyphTrieBranchCount];
 };
 
 struct HFGlyphTrieLeaf_t {
@@ -46,4 +48,4 @@ __private_extern__ struct HFGlyph_t HFGlyphTrieGet(const struct HFGlyphTrie_t *t
 /* Frees all storage associated with a glyph tree.  This is not necessary to call under GC. */
 __private_extern__ void HFGlyphTreeFree(struct HFGlyphTrie_t * trie);
 
-
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFHexPasteboardOwner.h
+++ b/framework/sources/HFHexPasteboardOwner.h
@@ -7,6 +7,8 @@
 
 #import <HexFiend/HFPasteboardOwner.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface HFHexPasteboardOwner : HFPasteboardOwner {
     NSUInteger _bytesPerColumn;
 }
@@ -16,3 +18,5 @@
 - (NSString *)stringFromByteArray:(HFByteArray *)byteArray ofLength:(unsigned long long)length trackingProgress:(HFProgressTracker *)tracker;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFLayoutRepresenter.h
+++ b/framework/sources/HFLayoutRepresenter.h
@@ -7,6 +7,8 @@
 
 #import <HexFiend/HFRepresenter.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @class HFLayoutRepresenter
     @brief An HFRepresenter responsible for arranging the views of other HFRepresenters attached to the same HFController.
     
@@ -78,3 +80,5 @@
 //@}
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFLineCountingRepresenter.h
+++ b/framework/sources/HFLineCountingRepresenter.h
@@ -7,6 +7,8 @@
 
 #import <HexFiend/HFRepresenter.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @enum HFLineNumberFormat
     HFLineNumberFormat is a simple enum used to determine whether line numbers are in decimal or hexadecimal format.
 */
@@ -67,3 +69,5 @@ extern NSString *const HFLineCountingRepresenterMinimumViewWidthChanged;
 /*! Notification posted when the HFLineCountingRepresenter has cycled through the line number format.  The object is the HFLineCountingRepresenter; there is no user info.
  */
 extern NSString *const HFLineCountingRepresenterCycledLineNumberFormat;
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFLineCountingView.h
+++ b/framework/sources/HFLineCountingView.h
@@ -20,12 +20,12 @@
     BOOL registeredForAppNotifications;
 }
 
-@property (nonatomic, copy) NSFont *font;
+@property (nullable, nonatomic, copy) NSFont *font;
 @property (nonatomic) CGFloat lineHeight;
 @property (nonatomic) HFFPRange lineRangeToDraw;
 @property (nonatomic) NSUInteger bytesPerLine;
 @property (nonatomic) HFLineNumberFormat lineNumberFormat;
-@property (nonatomic, assign) HFLineCountingRepresenter *representer;
+@property (nullable, nonatomic, assign) HFLineCountingRepresenter *representer;
 
 + (NSUInteger)digitsRequiredToDisplayLineNumber:(unsigned long long)lineNumber inFormat:(HFLineNumberFormat)format;
 

--- a/framework/sources/HFObjectGraph.h
+++ b/framework/sources/HFObjectGraph.h
@@ -7,6 +7,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface HFObjectGraph : NSObject {
     __strong CFMutableDictionaryRef graph;
@@ -14,13 +15,15 @@
 }
 
 - (void)addDependency:depend forObject:obj;
-- (NSSet *)dependenciesForObject:obj;
+- (nullable NSSet *)dependenciesForObject:obj;
 - (BOOL)object:obj hasDependency:depend;
 
 /* Returns an NSArray of NSArrays of objects representing the strongly connected components of the graph, via Tarjan's algorithm. */
-- (NSArray *)stronglyConnectedComponentsForObjects:(NSArray *)objects;
+- (NSArray *)stronglyConnectedComponentsForObjects:(nullable NSArray *)objects;
 
 /* Returns an NSArray of the objects topologically sorted via the dependencies in self.  self must be acyclic; if there is a cycle an exception will be thrown. */
 - (NSArray *)topologicallySortObjects:(NSArray *)objects;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFPasteboardOwner.h
+++ b/framework/sources/HFPasteboardOwner.h
@@ -7,6 +7,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFByteArray, HFProgressTracker;
 
 extern NSString *const HFPrivateByteArrayPboardType;
@@ -32,7 +34,7 @@ extern NSString *const HFPrivateByteArrayPboardType;
 - (HFByteArray *)byteArray;
 
 /* Performs a copy to pasteboard with progress reporting. This must be overridden if you support types other than the private pboard type. */
-- (void)writeDataInBackgroundToPasteboard:(NSPasteboard *)pboard ofLength:(unsigned long long)length forType:(NSString *)type trackingProgress:(HFProgressTracker *)tracker;
+- (void)writeDataInBackgroundToPasteboard:(NSPasteboard *)pboard ofLength:(unsigned long long)length forType:(NSString *)type trackingProgress:(nullable HFProgressTracker *)tracker;
 
 /* NSPasteboard delegate methods, declared here to indicate that subclasses should call super */
 - (void)pasteboard:(NSPasteboard *)sender provideDataForType:(NSString *)type;
@@ -45,7 +47,7 @@ extern NSString *const HFPrivateByteArrayPboardType;
 + (NSString *)uuid;
 
 /* Unpacks a byte array from a pasteboard, preferring HFPrivateByteArrayPboardType */
-+ (HFByteArray *)unpackByteArrayFromPasteboard:(NSPasteboard *)pasteboard;
++ (nullable HFByteArray *)unpackByteArrayFromPasteboard:(NSPasteboard *)pasteboard;
 
 /* Used to handle the case where copying data will require a lot of memory and give the user a chance to confirm. */
 - (unsigned long long)amountToCopyForDataLength:(unsigned long long)numBytes stringLength:(unsigned long long)stringLength;
@@ -54,3 +56,5 @@ extern NSString *const HFPrivateByteArrayPboardType;
 - (unsigned long long)stringLengthForDataLength:(unsigned long long)dataLength;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFPrivilegedHelperConnection.h
+++ b/framework/sources/HFPrivilegedHelperConnection.h
@@ -8,6 +8,7 @@
 #import <Cocoa/Cocoa.h>
 #import "FortunateSonIPCTypes.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 struct HFProcessInfo_t {
     unsigned char bits; //either 32 or 64
@@ -31,3 +32,5 @@ struct HFProcessInfo_t {
 - (BOOL)openFileAtPath:(const char *)path writable:(BOOL)writable fileDescriptor:(int *)outFD error:(NSError **)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFProgressTracker.h
+++ b/framework/sources/HFProgressTracker.h
@@ -8,6 +8,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
 @class HFProgressTracker
 @brief A class that helps handle progress indication and cancellation for long running threaded operations.
@@ -51,7 +53,7 @@
 /*!
   The progressIndicator property allows an NSProgressIndicator to be associated with the HFProgressTracker.  The progress indicator should have values in the range 0 to 1, and it will be updated with the fraction currentProgress / maxProgress.
 */
-@property (nonatomic, strong) NSProgressIndicator *progressIndicator;
+@property (nullable, nonatomic, strong) NSProgressIndicator *progressIndicator;
 
 /*!
   Called to indicate you want to begin tracking the progress, which means that the progress indicator will be updated, and the delegate callbacks may fire.
@@ -76,7 +78,7 @@
 /*!
   Set and get the delegate, which may implement the optional methods below.
 */
-@property (nonatomic, assign) id delegate;
+@property (nullable, nonatomic, assign) id delegate;
 
 @end
 
@@ -100,3 +102,5 @@ The HFProgressTrackerDelegate methods are called on the the HFProgressTracker's 
 - (void)progressTrackerDidFinish:(HFProgressTracker *)tracker;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFRepresenter.h
+++ b/framework/sources/HFRepresenter.h
@@ -8,6 +8,8 @@
 #import <Cocoa/Cocoa.h>
 #import <HexFiend/HFController.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @class HFRepresenter
     @brief The principal view class of Hex Fiend's MVC architecture.
     
@@ -59,7 +61,7 @@
 */
 //@{
 /*! Returns the HFController for the receiver.  This is set by the controller from the call to \c addRepresenter:. A representer can only be in one controller at a time. */
-- (HFController *)controller;
+- (nullable HFController *)controller;
 //@}
 
 /*! @name Property change notifications
@@ -119,3 +121,5 @@
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFRepresenterTextView.h
+++ b/framework/sources/HFRepresenterTextView.h
@@ -17,6 +17,8 @@
     Since a value of zero is nonsensical, we can use it to specify no spaces at all.
 */
 
+NS_ASSUME_NONNULL_BEGIN
+
 #define HFTV_BYTES_PER_COLUMN_MAX_VALUE (1 << (HFTV_BYTES_PER_COLUMN_BITFIELD_SIZE - 1))
 
 @class HFTextRepresenter;
@@ -65,7 +67,7 @@
 @property (nonatomic) CGFloat verticalOffset;
 @property (nonatomic) NSUInteger startingLineBackgroundColorIndex;
 @property (nonatomic, getter=isEditable) BOOL editable;
-@property (nonatomic, copy) NSArray *styles;
+@property (nullable, nonatomic, copy) NSArray *styles;
 @property (nonatomic) BOOL shouldAntialias;
 
 - (BOOL)behavesAsTextField;
@@ -77,7 +79,7 @@
 - (void)setBookmarks:(NSDictionary *)bookmarks;
 @property (nonatomic) BOOL shouldDrawCallouts;
 
-- (void)setByteColoring:(void (^)(uint8_t byte, uint8_t *r, uint8_t *g, uint8_t *b, uint8_t *a))coloring;
+- (void)setByteColoring:(nullable void (^)(uint8_t byte, uint8_t *r, uint8_t *g, uint8_t *b, uint8_t *a))coloring;
 
 - (NSPoint)originForCharacterAtByteIndex:(NSInteger)index;
 - (NSUInteger)indexOfCharacterAtPoint:(NSPoint)point;
@@ -98,12 +100,12 @@
 /* Uniformly "rounds" the byte range so that it contains an integer number of characters.  The algorithm is to "floor:" any character intersecting the min of the range are included, and any character extending beyond the end of the range is excluded. If both the min and the max are within a single character, then an empty range is returned. */
 - (NSRange)roundPartialByteRange:(NSRange)byteRange;
 
-- (void)drawTextWithClip:(NSRect)clipRect restrictingToTextInRanges:(NSArray *)restrictingToRanges;
+- (void)drawTextWithClip:(NSRect)clipRect restrictingToTextInRanges:(nullable NSArray *)restrictingToRanges;
 
 /* Must be overridden */
 - (void)extractGlyphsForBytes:(const unsigned char *)bytes count:(NSUInteger)numBytes offsetIntoLine:(NSUInteger)offsetIntoLine intoArray:(struct HFGlyph_t *)glyphs advances:(CGSize *)advances resultingGlyphCount:(NSUInteger *)resultGlyphCount;
 
-- (void)extractGlyphsForBytes:(const unsigned char *)bytePtr range:(NSRange)byteRange intoArray:(struct HFGlyph_t *)glyphs advances:(CGSize *)advances withInclusionRanges:(NSArray *)restrictingToRanges initialTextOffset:(CGFloat *)initialTextOffset resultingGlyphCount:(NSUInteger *)resultingGlyphCount;
+- (void)extractGlyphsForBytes:(const unsigned char *)bytePtr range:(NSRange)byteRange intoArray:(struct HFGlyph_t *)glyphs advances:(CGSize *)advances withInclusionRanges:(NSArray *)restrictingToRanges initialTextOffset:(CGFloat *)initialTextOffset resultingGlyphCount:(nullable NSUInteger *)resultingGlyphCount;
 
 /* Must be overridden - returns the max number of glyphs for a given number of bytes */
 - (NSUInteger)maximumGlyphCountForByteCount:(NSUInteger)byteCount;
@@ -117,7 +119,7 @@
 - (NSRect)furthestRectOnEdge:(NSRectEdge)edge forRange:(NSRange)range;
 
 /* The background color for the line at the given index.  You may override this to return different colors.  You may return nil to draw no color in this line (and then the empty space color will appear) */
-- (NSColor *)backgroundColorForLine:(NSUInteger)line;
+- (nullable NSColor *)backgroundColorForLine:(NSUInteger)line;
 - (NSColor *)backgroundColorForEmptySpace;
 
 /* Defaults to 1, may override */
@@ -146,3 +148,5 @@
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFRepresenterTextViewCallout.h
+++ b/framework/sources/HFRepresenterTextViewCallout.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFRepresenterTextView;
 
 #define kHFRepresenterTextViewCalloutMaxGlyphCount 2u
@@ -18,9 +20,9 @@
 }
 
 @property(nonatomic) NSInteger byteOffset;
-@property(nonatomic, copy) NSColor *color;
-@property(nonatomic, copy) NSString *label;
-@property(nonatomic, retain) id representedObject;
+@property(nullable, nonatomic, copy) NSColor *color;
+@property(nullable, nonatomic, copy) NSString *label;
+@property(nullable, nonatomic, retain) id representedObject;
 @property(readonly) NSRect rect;
 
 + (void)layoutCallouts:(NSArray *)callouts inView:(HFRepresenterTextView *)textView;
@@ -29,3 +31,6 @@
 - (void)drawWithClip:(NSRect)clip;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/framework/sources/HFRepresenterTextView_Internal.h
+++ b/framework/sources/HFRepresenterTextView_Internal.h
@@ -1,11 +1,15 @@
 #import <HexFiend/HFRepresenterTextView.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 #define GLYPH_BUFFER_SIZE 16u
 
 @interface HFRepresenterTextView (HFInternal)
 
-- (NSUInteger)_glyphsForString:(NSString *)string withGeneratingLayoutManager:(NSLayoutManager *)textView glyphs:(CGGlyph *)glyphs;
-- (NSUInteger)_glyphsForString:(NSString *)string withGeneratingTextView:(NSTextView *)textView glyphs:(CGGlyph *)glyphs;
+- (NSUInteger)_glyphsForString:(NSString *)string withGeneratingLayoutManager:(NSLayoutManager *)textView glyphs:(nullable CGGlyph *)glyphs;
+- (NSUInteger)_glyphsForString:(NSString *)string withGeneratingTextView:(NSTextView *)textView glyphs:(nullable CGGlyph *)glyphs;
 - (NSUInteger)_getGlyphs:(CGGlyph *)glyphs forString:(NSString *)string font:(NSFont *)font; //uses CoreText.  Here glyphs must have space for [string length] glyphs.
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFRepresenter_Internal.h
+++ b/framework/sources/HFRepresenter_Internal.h
@@ -2,6 +2,6 @@
 
 @interface HFRepresenter (HFInternalStuff)
 
-- (void)_setController:(HFController *)controller;
+- (void)_setController:(nullable HFController *)controller;
 
 @end

--- a/framework/sources/HFSharedMemoryByteSlice.h
+++ b/framework/sources/HFSharedMemoryByteSlice.h
@@ -7,6 +7,8 @@
 
 #import <HexFiend/HFByteSlice.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @class HFSharedMemoryByteSlice
     @brief A subclass of HFByteSlice for working with data stored in memory.
     
@@ -30,3 +32,5 @@
 - (instancetype)initWithData:(NSMutableData *)data offset:(NSUInteger)offset length:(NSUInteger)length;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFTextRepresenter.h
+++ b/framework/sources/HFTextRepresenter.h
@@ -8,6 +8,8 @@
 #import <HexFiend/HFRepresenter.h>
 #import <HexFiend/HFByteArray.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @class HFTextRepresenter
     @brief An HFRepresenter that draws text (e.g. the hex or ASCII view).
     
@@ -39,3 +41,5 @@
 - (void)selectAll:(id)sender;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFTextRepresenter_Internal.h
+++ b/framework/sources/HFTextRepresenter_Internal.h
@@ -1,10 +1,12 @@
 #import <HexFiend/HFTextRepresenter.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface HFTextRepresenter (HFInternal)
 
 - (NSArray *)displayedSelectedContentsRanges; //returns an array of NSValues representing the selected ranges (as NSRanges) clipped to the displayed range.
 
-- (NSDictionary *)displayedBookmarkLocations; //returns an dictionary mapping bookmark names to bookmark locations. Bookmark locations may be negative.
+- (nullable NSDictionary *)displayedBookmarkLocations; //returns an dictionary mapping bookmark names to bookmark locations. Bookmark locations may be negative.
 
 - (void)beginSelectionWithEvent:(NSEvent *)event forCharacterIndex:(NSUInteger)characterIndex;
 - (void)continueSelectionWithEvent:(NSEvent *)event forCharacterIndex:(NSUInteger)characterIndex;
@@ -32,3 +34,5 @@
 - (void)selectAll:(id)sender;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFTextSelectionPulseView.h
+++ b/framework/sources/HFTextSelectionPulseView.h
@@ -7,6 +7,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface HFTextSelectionPulseView : NSView {
     NSImage *image;
@@ -15,3 +16,5 @@
 - (void)setImage:(NSImage *)val;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/framework/sources/HFTextView.h
+++ b/framework/sources/HFTextView.h
@@ -8,6 +8,8 @@
 #import <Cocoa/Cocoa.h>
 #import <HexFiend/HFController.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class HFLayoutRepresenter;
 
 /*! @class HFTextView
@@ -51,7 +53,7 @@
 //@}
 
 /// The delegate, which may implement the methods in HFTextViewDelegate. Initially nil.
-@property (nonatomic, assign) id delegate;
+@property (nullable, nonatomic, assign) id delegate;
 
 /*! Access the contents of the HFTextView's HFByteArray as an NSData.
     When setting, the data is copied via the `-copy` message, so prefer to pass an immutable `NSData` when possible.
@@ -59,7 +61,7 @@
 
    For those reasons, this should only be used when its convenience outweighs the downside (e.g. some bindings scenarios).  For most use cases, it is better to use the `-byteArray` method above.
 */
-@property (nonatomic, copy) NSData *data;
+@property (nullable, nonatomic, copy) NSData *data;
 
 
 @end
@@ -73,3 +75,5 @@
 - (void)hexTextView:(HFTextView *)view didChangeProperties:(HFControllerPropertyBits)properties;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
In addition to better interoperability with Swift, it also allows the compiler, static analyser, and undefined behaviour sanitiser to spot accidental usages of `NULL` or `nil`.

I've tested this briefly, through running the static analyser, running the Hex Fiend app on a small file, and running the framework tests (with the undefined behaviour sanitiser on). Feel free to make more things `nullable` as necessary, and/or move away from `NS_ASSUME_NONNULL` if you like.