### PR TITLE
Fixes Bug Report #125 - Unselecting Encoding sets to default MacRoman.

### DIFF
--- a/app/sources/ChooseStringEncodingWindowController.m
+++ b/app/sources/ChooseStringEncodingWindowController.m
@@ -248,6 +248,8 @@ static void addEncoding(NSString *name, CFStringEncoding value, NSMutableArray<H
 {
     NSInteger row = tableView.selectedRow;
     if (row == -1) {
+        NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:0];
+        [tableView selectRowIndexes:indexSet byExtendingSelection:NO];
         return;
     }
     /* Tell the front document (if any) and the app delegate */


### PR DESCRIPTION
HexFiend defaults to MacRoman encoding, deselecting Encoding from the _Choose Encoding_ dialog, brings it back to MacRoman.