### PR TITLE
Fix download behind proxy

### DIFF
--- a/app/get_sparkle.sh
+++ b/app/get_sparkle.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This script should be called from the root directory
 
 set -e
@@ -20,7 +21,7 @@ if [ -e "$FRAMEWORK" ]; then
 fi
 
 # Download Sparkle
-curl -sL -o "$ARCHIVE" "$URL"
+nscurl -o "$ARCHIVE" "$URL"
 
 # Extract Sparkle.framework
 tar -xvf "$ARCHIVE" "$FRAMEWORK"


### PR DESCRIPTION
If you build HexFiend on a system behind a proxy server, the download
of Sparkle fails --> use `nscurl` instead of `curl`

see https://github.com/ridiculousfish/HexFiend/issues/152