### PR TITLE
Ignore AppCode specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ HexFiend_2.xcodeproj/project.xcworkspace/*
 HexFiend_2.xcodeproj/xcuserdata/*
 /build
 /vendor
+
+# Ignore AppCode specific files completely
+.idea/


### PR DESCRIPTION
Ignore AppCode specific files 

Ignore AppCode specific files completely. If you want to allow AppCode specific files in Git, see https://www.gitignore.io/api/AppCode for more detailed configuration.