### PR TITLE
Adds a defaults key for auto-collapsing valued groups.

### DIFF
--- a/app/sources/BaseDataDocument.m
+++ b/app/sources/BaseDataDocument.m
@@ -97,6 +97,7 @@ static inline Class preferredByteArrayClass(void) {
             @"BinaryTemplateScriptTimeout" : @(10),
             @"BinaryTemplatesSingleClickAction" : @(1), // scroll to offset
             @"BinaryTemplatesDoubleClickAction" : @(0), // do nothing
+            @"BinaryTemplatesAutoCollapseValuedSections" : @NO,
             @"ResolveAliases": @YES,
         };
         [[NSUserDefaults standardUserDefaults] registerDefaults:defs];

--- a/app/sources/HFBinaryTemplateController.m
+++ b/app/sources/HFBinaryTemplateController.m
@@ -242,6 +242,21 @@
     return nil;
 }
 
+- (void)collapseValuedGroups {
+    NSOutlineView *outlineView = self.outlineView;
+    NSInteger numberOfRows = outlineView.numberOfRows;
+    NSMutableArray<HFTemplateNode *> *nodesToCollapse = [NSMutableArray array];
+    for (NSInteger i = 0; i < numberOfRows; ++i) {
+        HFTemplateNode *node = [outlineView itemAtRow:i];
+        if (node.isGroup && node.value) {
+            [nodesToCollapse addObject:node];
+        }
+    }
+    for (HFTemplateNode *node in nodesToCollapse) {
+        [self.outlineView collapseItem:node];
+    }
+}
+
 - (void)setRootNode:(HFTemplateNode *)node error:(NSString *)error {
     if (error != nil) {
         self.node = nil;
@@ -253,6 +268,9 @@
     }
     [self.outlineView reloadData];
     [self.outlineView expandItem:nil expandChildren:YES];
+    if ([NSUserDefaults.standardUserDefaults boolForKey:@"BinaryTemplatesAutoCollapseValuedGroups"]) {
+        [self collapseValuedGroups];
+    }
 }
 
 - (NSColor *)selectionColor {

--- a/app/sources/HFBinaryTemplateController.m
+++ b/app/sources/HFBinaryTemplateController.m
@@ -245,15 +245,11 @@
 - (void)collapseValuedGroups {
     NSOutlineView *outlineView = self.outlineView;
     NSInteger numberOfRows = outlineView.numberOfRows;
-    NSMutableArray<HFTemplateNode *> *nodesToCollapse = [NSMutableArray array];
-    for (NSInteger i = 0; i < numberOfRows; ++i) {
+    for (NSInteger i = numberOfRows - 1; i >=0; --i) {
         HFTemplateNode *node = [outlineView itemAtRow:i];
         if (node.isGroup && node.value) {
-            [nodesToCollapse addObject:node];
+            [outlineView collapseItem:node];
         }
-    }
-    for (HFTemplateNode *node in nodesToCollapse) {
-        [outlineView collapseItem:node];
     }
 }
 

--- a/app/sources/HFBinaryTemplateController.m
+++ b/app/sources/HFBinaryTemplateController.m
@@ -253,7 +253,7 @@
         }
     }
     for (HFTemplateNode *node in nodesToCollapse) {
-        [self.outlineView collapseItem:node];
+        [outlineView collapseItem:node];
     }
 }
 

--- a/app/sources/HFTemplateNode.h
+++ b/app/sources/HFTemplateNode.h
@@ -14,7 +14,7 @@
 - (instancetype)initGroupWithLabel:(NSString *)label parent:(HFTemplateNode *)parent;
 
 @property (readonly) NSString *label;
-@property (readwrite) NSString *value;
+@property (copy) NSString *value;
 @property (readonly) BOOL isGroup;
 @property (readonly, weak) HFTemplateNode *parent;
 


### PR DESCRIPTION
Also makes HFTemplateNode's value copy (in case of mutable strings).