### PR TITLE
Fix capitalization of Font > Color Bytes menu item

### DIFF
--- a/app/resources/Base.lproj/MainMenu.xib
+++ b/app/resources/Base.lproj/MainMenu.xib
@@ -389,7 +389,7 @@
                                     <action selector="setAntialiasFromMenuItem:" target="-1" id="xJB-SX-oT5"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Color bytes" id="HpS-tB-2Bk">
+                            <menuItem title="Color Bytes" id="HpS-tB-2Bk">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="setColorBytesFromMenuItem:" target="-1" id="rFc-gy-jE3"/>


### PR DESCRIPTION
[Accoridng to Apple’s Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/macos/menus/menu-anatomy/#menu-and-menu-item-titles), menu items should use title-style capitalization.

I checked all the other menu items in this file and they are correctly capitalized.

### Before

<img width="315" alt="before: “Color bytes”" src="https://user-images.githubusercontent.com/79168/51446454-612b7200-1ce0-11e9-8df5-53f292732a23.png">

### After

<img width="315" alt="after: “Color Bytes”" src="https://user-images.githubusercontent.com/79168/51446455-64266280-1ce0-11e9-9d97-f1b6243978df.png">
