### PR TITLE
Rearrange the Font menu to make the non-font items noticeable

### DIFF
--- a/app/resources/Base.lproj/MainMenu.xib
+++ b/app/resources/Base.lproj/MainMenu.xib
@@ -300,10 +300,6 @@
                 <menuItem title="Font" id="409">
                     <menu key="submenu" title="Font" id="410">
                         <items>
-                            <menuItem title="Building..." enabled="NO" id="411"/>
-                            <menuItem isSeparatorItem="YES" id="414">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
                             <menuItem title="Size" id="416">
                                 <menu key="submenu" title="Size" id="417">
                                     <items>
@@ -403,6 +399,10 @@
                                     <action selector="showFontPanel:" target="-1" id="456"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="414">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Building font list…" enabled="NO" id="411"/>
                         </items>
                         <connections>
                             <outlet property="delegate" destination="403" id="412"/>
@@ -657,6 +657,7 @@
                 <outlet property="byteGroupingMenuItem" destination="488" id="U3v-Jk-eKP"/>
                 <outlet property="chooseStringEncoding" destination="680" id="k0D-Q1-3F6"/>
                 <outlet property="extendForwardsItem" destination="397" id="407"/>
+                <outlet property="fontListPlaceholderMenuItem" destination="411" id="LQp-2v-HO1"/>
                 <outlet property="fontMenuItem" destination="409" id="413"/>
                 <outlet property="noBookmarksMenuItem" destination="8Hb-Ga-nGj" id="cOn-oy-A85"/>
                 <outlet property="stringEncodingMenu" destination="684" id="716"/>

--- a/app/sources/AppDelegate.h
+++ b/app/sources/AppDelegate.h
@@ -12,6 +12,7 @@
 @interface AppDelegate : NSObject {
     IBOutlet NSMenuItem *extendForwardsItem, *extendBackwardsItem;
     IBOutlet NSMenuItem *fontMenuItem;
+    IBOutlet NSMenuItem *fontListPlaceholderMenuItem;
     IBOutlet NSMenuItem *processListMenuItem;
     IBOutlet NSMenu *bookmarksMenu;
     IBOutlet NSMenuItem *noBookmarksMenuItem;

--- a/app/sources/AppDelegate.m
+++ b/app/sources/AppDelegate.m
@@ -191,8 +191,9 @@ static NSComparisonResult compareFontDisplayNames(NSFont *a, NSFont *b, void *un
 
 - (void)receiveFonts:(NSArray *)fonts {
     NSMenu *menu = [fontMenuItem submenu];
-    [menu removeItemAtIndex:0];
-    NSUInteger itemIndex = 0;
+    NSMenuItem *placeholderMenuItem = fontListPlaceholderMenuItem;
+    NSUInteger itemIndex = [menu indexOfItem:placeholderMenuItem];
+    [menu removeItemAtIndex:itemIndex];
     for(NSFont *font in fonts) {
         NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:[font displayName] action:@selector(setFontFromMenuItem:) keyEquivalent:@""];
         NSDictionary *attrs = @{

--- a/app/sources/AppDelegate.m
+++ b/app/sources/AppDelegate.m
@@ -191,9 +191,8 @@ static NSComparisonResult compareFontDisplayNames(NSFont *a, NSFont *b, void *un
 
 - (void)receiveFonts:(NSArray *)fonts {
     NSMenu *menu = [fontMenuItem submenu];
-    NSMenuItem *placeholderMenuItem = fontListPlaceholderMenuItem;
-    NSUInteger itemIndex = [menu indexOfItem:placeholderMenuItem];
-    [menu removeItemAtIndex:itemIndex];
+    NSUInteger indexOfItemToAdd = [menu indexOfItem:fontListPlaceholderMenuItem];
+    [menu removeItem:fontListPlaceholderMenuItem];
     for(NSFont *font in fonts) {
         NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:[font displayName] action:@selector(setFontFromMenuItem:) keyEquivalent:@""];
         NSDictionary *attrs = @{
@@ -203,7 +202,7 @@ static NSComparisonResult compareFontDisplayNames(NSFont *a, NSFont *b, void *un
         [item setAttributedTitle:astr];
         [item setRepresentedObject:font];
         [item setTarget:self];
-        [menu insertItem:item atIndex:itemIndex++];
+        [menu insertItem:item atIndex:indexOfItemToAdd++];
         /* Validate the menu item in case the menu is currently open, so it gets the right check */
         [self validateMenuItem:item];
     }


### PR DESCRIPTION
Before, depending on the screen size and the number of fonts installed, the menu items that didn’t choose a font could be hidden below the bottom of the menu, which made those menu items hard to discover. Now they are discoverable.

I also renamed the placeholder from “Building...” to “Building font list…” and added an outlet so that the placeholder can be moved in the future without having to update the code.

I made this change because until [kainjow mentioned it](https://github.com/ridiculousfish/HexFiend/issues/181#issuecomment-455815264), I didn’t know that the Color Bytes feature existed, even though I had looked at the Font menu the day before.

I have very little experience in writing Objective-C or using outlets, so please let me know if I did anything wrong.

## Screenshots of the Font menu before and after

### Before: only fonts were visible without scrolling

<img width="1440" alt="Font menu in which only fonts are visible" src="https://user-images.githubusercontent.com/79168/51447683-8921d200-1cee-11e9-9de5-2024443ed829.png">

### After: all types of menu items are visible without scrolling

<img width="1440" alt="Font menu with menu items like “Size” about the list of fonts" src="https://user-images.githubusercontent.com/79168/51447755-1a914400-1cef-11e9-89ae-94a2e72af0d0.png">

### Before: while fonts are still loading

<img width="168" alt="loading font menu with “Building...” at the top" src="https://user-images.githubusercontent.com/79168/51447766-3f85b700-1cef-11e9-918f-711fcffbfee8.png">

### After: while fonts are still loading

<img width="189" alt="loading font menu with “Building font list…” at the bottom" src="https://user-images.githubusercontent.com/79168/51447769-48768880-1cef-11e9-9e64-bb34a4577fa2.png">