### PR TITLE
Support text search when using custom text encoding

### DIFF
--- a/framework/sources/HFCustomEncoding.m
+++ b/framework/sources/HFCustomEncoding.m
@@ -14,6 +14,7 @@
 @property NSString *nameValue;
 @property NSString *identifierValue;
 @property NSDictionary<NSNumber *, NSString *> *charToStringMap;
+@property NSDictionary<NSString *, NSNumber *> *stringToCharMap;
 
 @end
 
@@ -42,6 +43,7 @@
         return NO;
     }
     NSMutableDictionary *nsMap = [NSMutableDictionary dictionary];
+    NSMutableDictionary *nsMapInverted = [NSMutableDictionary dictionary];
     for (NSString *key in map) {
         NSScanner *scanner = [NSScanner scannerWithString:key];
         unsigned int intKey = 0;
@@ -59,11 +61,13 @@
             return NO;
         }
         nsMap[@(intKey)] = value;
+        nsMapInverted[value] = @(intKey);
     }
     _path = path;
     _nameValue = name;
     _identifierValue = identifier;
     _charToStringMap = nsMap;
+    _stringToCharMap = nsMapInverted;
     return YES;
 }
 
@@ -101,8 +105,15 @@
 }
 
 - (NSData *)dataFromString:(NSString *)string {
-    NSLog(@"UNIMPLEMENTED: %@", string);
-    return nil;
+    NSMutableData *bytes = [NSMutableData dataWithLength: 0];
+    for (NSUInteger i = 0; i < string.length; ++i) {
+        NSString *str = [NSString stringWithFormat:@"%C", [string characterAtIndex: i]];
+        unsigned char byte = self.stringToCharMap[str].unsignedCharValue;
+        if (byte) {
+            [bytes appendBytes: &byte length: sizeof(byte)];
+        }
+    }
+    return bytes;
 }
 
 - (NSString *)name {

--- a/framework/sources/HFCustomEncoding.m
+++ b/framework/sources/HFCustomEncoding.m
@@ -105,12 +105,12 @@
 }
 
 - (NSData *)dataFromString:(NSString *)string {
-    NSMutableData *bytes = [NSMutableData dataWithLength: 0];
+    NSMutableData *bytes = NSMutableData.data;
     for (NSUInteger i = 0; i < string.length; ++i) {
-        NSString *str = [NSString stringWithFormat:@"%C", [string characterAtIndex: i]];
+        NSString *str = [NSString stringWithFormat:@"%C", [string characterAtIndex:i]];
         unsigned char byte = self.stringToCharMap[str].unsignedCharValue;
         if (byte) {
-            [bytes appendBytes: &byte length: sizeof(byte)];
+            [bytes appendBytes:&byte length:sizeof(byte)];
         }
     }
     return bytes;


### PR DESCRIPTION
When using a custom text encoding, it is not possible to search for text strings. As soon as you start typing, you're alerted that "the text could not be converted to current encoding."

![](https://user-images.githubusercontent.com/35639/74489020-4536d780-4ec4-11ea-9318-5d4524b9af13.png)

The screenshot above shows the "Failed to convert text" dialog. This pull request gets rid of that and enables text search when using custom text encoding.