### PR TITLE
Add FAT date support for template

### DIFF
--- a/app/sources/HFTclTemplateController.m
+++ b/app/sources/HFTclTemplateController.m
@@ -37,6 +37,7 @@ enum command {
     command_float,
     command_double,
     command_macdate,
+    command_fatdate,
     command_unixtime32,
     command_unixtime64,
     command_bytes,
@@ -86,6 +87,7 @@ DEFINE_COMMAND(int8)
 DEFINE_COMMAND(float)
 DEFINE_COMMAND(double)
 DEFINE_COMMAND(macdate)
+DEFINE_COMMAND(fatdate)
 DEFINE_COMMAND(unixtime32)
 DEFINE_COMMAND(unixtime64)
 DEFINE_COMMAND(big_endian)
@@ -149,6 +151,7 @@ DEFINE_COMMAND(uint64_bits)
         CMD(float),
         CMD(double),
         CMD(macdate),
+        CMD(fatdate)
         CMD(unixtime32),
         CMD(unixtime64),
         CMD(big_endian),
@@ -276,6 +279,7 @@ DEFINE_COMMAND(uint64_bits)
         case command_float:
         case command_double:
         case command_macdate:
+        case command_fatdate:
         case command_unixtime32:
         case command_unixtime64:
         case command_uuid:
@@ -721,6 +725,16 @@ DEFINE_COMMAND(uint64_bits)
                 return TCL_ERROR;
             }
             Tcl_SetObjResult(_interp, Tcl_NewDoubleObj(date.timeIntervalSince1970));
+            break;
+        }
+        case command_fatdate: {
+            NSString *dateErr = nil;
+            NSString *date = [self readFatDateWithLabel:label error:&dateErr];
+            if (!date) {
+                Tcl_SetObjResult(_interp, Tcl_NewStringObj(dateErr.UTF8String, -1));
+                return TCL_ERROR;
+            }
+            Tcl_SetObjResult(_interp, Tcl_NewStringObj(date.UTF8String, -1));
             break;
         }
         case command_unixtime32:

--- a/app/sources/HFTclTemplateController.m
+++ b/app/sources/HFTclTemplateController.m
@@ -151,7 +151,7 @@ DEFINE_COMMAND(uint64_bits)
         CMD(float),
         CMD(double),
         CMD(macdate),
-        CMD(fatdate)
+        CMD(fatdate),
         CMD(unixtime32),
         CMD(unixtime64),
         CMD(big_endian),

--- a/app/sources/HFTemplateController.h
+++ b/app/sources/HFTemplateController.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSUInteger, HFEndian) {
 - (BOOL)readFloat:(float *)value forLabel:(NSString *_Nullable)label;
 - (BOOL)readDouble:(double *)value forLabel:(NSString *_Nullable)label;
 - (BOOL)readMacDate:(NSDate *_Nonnull*_Nonnull)value forLabel:(NSString *_Nullable)label;
+- (NSString *_Nullable)readFatDateWithLabel:(NSString *_Nullable)label error:(NSString *_Nonnull*_Nonnull)error;
 - (NSDate *_Nullable)readUnixTime:(unsigned)numBytes forLabel:(NSString *_Nullable)label error:(NSString *_Nonnull*_Nonnull)error;
 
 - (BOOL)readUUID:(NSUUID *_Nonnull*_Nonnull)uuid forLabel:(NSString *_Nullable)label;

--- a/app/sources/HFTemplateController.m
+++ b/app/sources/HFTemplateController.m
@@ -380,6 +380,26 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
     return YES;
 }
 
+- (NSString *)readFatDateWithLabel:(NSString *)label error:(NSString **)error {
+    int16_t val;
+    if (![self readInt16:&val forLabel:nil]) {
+        if (error) {
+            *error = @"Failed to read int16 bytes";
+        }
+        return nil;
+    }
+
+    NSInteger day = val & 0x1F;
+    NSInteger month = val >> 5 & 0xF;
+    NSInteger year = 1980 + ((val >> 9) & 0x7F);
+    NSString *date = [NSString stringWithFormat:@"%d-%02d-%02d", year, month, day];
+
+    if (label) {
+        [self addNodeWithLabel:label value:date size:sizeof(val)];
+    }
+    return date;
+}
+
 - (NSDate *)readUnixTime:(unsigned)numBytes forLabel:(NSString *)label error:(NSString **)error {
     time_t t;
     if (numBytes == 4) {

--- a/app/sources/HFTemplateController.m
+++ b/app/sources/HFTemplateController.m
@@ -389,9 +389,9 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
         return nil;
     }
 
-    NSInteger day = val & 0x1F;
-    NSInteger month = val >> 5 & 0xF;
-    NSInteger year = 1980 + ((val >> 9) & 0x7F);
+    int day = val & 0x1F;
+    int month = (val >> 5) & 0xF;
+    int year = 1980 + ((val >> 9) & 0x7F);
     NSString *date = [NSString stringWithFormat:@"%d-%02d-%02d", year, month, day];
 
     if (label) {

--- a/templates/Reference.md
+++ b/templates/Reference.md
@@ -30,6 +30,7 @@ set size [uint32]
 | double  | Reads a 64-bit floating point |
 | uuid    | Reads 16-byte UUID |
 | macdate | Reads classic Mac OS 4-byte date (seconds since January 1, 1904) |
+| fatdate | Reads FAT, or DOS, 2-byte date |
 
 As of v2.11+, unsigned integer types have an optional parameter `-hex` which causes the displayed value to be in hexadecimal, instead of decimal:
 


### PR DESCRIPTION
Add command `fatdate` to read a FAT date in a template.

I cannot compile the project in Xcode. I hope it will work...
Here are some values to test:

| data | date |
|------|-------|
| 0x0021 | 1980-01-01 |
| 0x197A | 1992-11-26 |
| 0x5042 | 2020-02-02 |
| 0xFF9F | 2107-12-31 |
