### PR TITLE
Fix custom encoding search

### DIFF
--- a/framework/sources/HFCustomEncoding.m
+++ b/framework/sources/HFCustomEncoding.m
@@ -136,7 +136,7 @@
 }
 
 - (NSData *)dataFromString:(NSString *)string {
-    NSMutableData *bytes = [NSMutableData dataWithLength:string.length * _bytesPerCharacter];
+    NSMutableData *bytes = [NSMutableData dataWithCapacity:string.length * _bytesPerCharacter];
     for (NSUInteger i = 0; i < string.length; ++i) {
         NSString *str = [NSString stringWithFormat:@"%C", [string characterAtIndex:i]];
         NSNumber *codepointNumber = self.stringToCharMap[str];

--- a/framework/sources/HFCustomEncoding.m
+++ b/framework/sources/HFCustomEncoding.m
@@ -155,7 +155,7 @@
             HFASSERT(0);
         }
     }
-    return bytes;
+    return bytes.length > 0 ? bytes : nil;
 }
 
 - (NSString *)name {


### PR DESCRIPTION
`bytes` should be empty from the start but `dataWithLength` returns a data object populated with zeroed bytes. 

>  `dataWithLength:` Creates and returns an mutable data object containing a given number of zeroed bytes.

– https://developer.apple.com/documentation/foundation/nsmutabledata/1547233-datawithlength?language=objc

