### PR TITLE
Add FAT time support for template

### DIFF
--- a/app/sources/HFTclTemplateController.m
+++ b/app/sources/HFTclTemplateController.m
@@ -38,6 +38,7 @@ enum command {
     command_double,
     command_macdate,
     command_fatdate,
+    command_fattime,
     command_unixtime32,
     command_unixtime64,
     command_bytes,
@@ -88,6 +89,7 @@ DEFINE_COMMAND(float)
 DEFINE_COMMAND(double)
 DEFINE_COMMAND(macdate)
 DEFINE_COMMAND(fatdate)
+DEFINE_COMMAND(fattime)
 DEFINE_COMMAND(unixtime32)
 DEFINE_COMMAND(unixtime64)
 DEFINE_COMMAND(big_endian)
@@ -152,6 +154,7 @@ DEFINE_COMMAND(uint64_bits)
         CMD(double),
         CMD(macdate),
         CMD(fatdate),
+        CMD(fattime),
         CMD(unixtime32),
         CMD(unixtime64),
         CMD(big_endian),
@@ -280,6 +283,7 @@ DEFINE_COMMAND(uint64_bits)
         case command_double:
         case command_macdate:
         case command_fatdate:
+        case command_fattime:
         case command_unixtime32:
         case command_unixtime64:
         case command_uuid:
@@ -735,6 +739,16 @@ DEFINE_COMMAND(uint64_bits)
                 return TCL_ERROR;
             }
             Tcl_SetObjResult(_interp, Tcl_NewStringObj(date.UTF8String, -1));
+            break;
+        }
+        case command_fattime: {
+            NSString *timeErr = nil;
+            NSString *time = [self readFatTimeWithLabel:label error:&timeErr];
+            if (!time) {
+                Tcl_SetObjResult(_interp, Tcl_NewStringObj(timeErr.UTF8String, -1));
+                return TCL_ERROR;
+            }
+            Tcl_SetObjResult(_interp, Tcl_NewStringObj(time.UTF8String, -1));
             break;
         }
         case command_unixtime32:

--- a/app/sources/HFTemplateController.h
+++ b/app/sources/HFTemplateController.h
@@ -60,6 +60,7 @@ typedef NS_ENUM(NSUInteger, HFEndian) {
 - (BOOL)readDouble:(double *)value forLabel:(NSString *_Nullable)label;
 - (BOOL)readMacDate:(NSDate *_Nonnull*_Nonnull)value forLabel:(NSString *_Nullable)label;
 - (NSString *_Nullable)readFatDateWithLabel:(NSString *_Nullable)label error:(NSString *_Nonnull*_Nonnull)error;
+- (NSString *_Nullable)readFatTimeWithLabel:(NSString *_Nullable)label error:(NSString *_Nonnull*_Nonnull)error;
 - (NSDate *_Nullable)readUnixTime:(unsigned)numBytes forLabel:(NSString *_Nullable)label error:(NSString *_Nonnull*_Nonnull)error;
 
 - (BOOL)readUUID:(NSUUID *_Nonnull*_Nonnull)uuid forLabel:(NSString *_Nullable)label;

--- a/app/sources/HFTemplateController.m
+++ b/app/sources/HFTemplateController.m
@@ -399,6 +399,26 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
     return date;
 }
 
+- (NSString *)readFatTimeWithLabel:(NSString *)label error:(NSString **)error {
+    int16_t val;
+    if (![self readInt16:&val forLabel:nil]) {
+        if (error) {
+            *error = @"Failed to read int16 bytes";
+        }
+        return nil;
+    }
+
+    int sec = (val & 0x1F) * 2;
+    int min = (val >> 5) & 0x3F;
+    int hour = (val >> 11) & 0x1F;
+    NSString *time = [NSString stringWithFormat:@"%02d:%02d:%02d UTC", hour, min, sec];
+
+    if (label) {
+        [self addNodeWithLabel:label value:time size:sizeof(val)];
+    }
+    return time;
+}
+
 - (NSDate *)readUnixTime:(unsigned)numBytes forLabel:(NSString *)label error:(NSString **)error {
     time_t t;
     if (numBytes == 4) {

--- a/templates/Reference.md
+++ b/templates/Reference.md
@@ -31,6 +31,7 @@ set size [uint32]
 | uuid    | Reads 16-byte UUID |
 | macdate | Reads classic Mac OS 4-byte date (seconds since January 1, 1904) |
 | fatdate | Reads FAT, or DOS, 2-byte date (v2.13+) |
+| fattime | Reads FAT, or DOS, 2-byte time (v2.13+) |
 
 As of v2.11+, unsigned integer types have an optional parameter `-hex` which causes the displayed value to be in hexadecimal, instead of decimal:
 


### PR DESCRIPTION
Add command `fattime` to read a FAT time in a template.

Here are some values to test:

|value|time|
|------|-----|
| 0x0000 | 00:00:00 UTC |
| 0x0821 | 01:01:02 UTC |
| 0x8C31 | 17:33:34 UTC |
| 0xBF7D | 23:59:58 UTC |
