### PR TITLE
Binary templates: include custom entries in section range

### DIFF
--- a/app/sources/HFTemplateController.m
+++ b/app/sources/HFTemplateController.m
@@ -526,15 +526,21 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
 }
 
 - (void)addEntryWithLabel:(NSString *)label value:(NSString *)value length:(unsigned long long *)length offset:(unsigned long long *)offset {
-    HFTemplateNode *node = [[HFTemplateNode alloc] initWithLabel:label value:value];
-    if (length && offset) {
-        node.range = HFRangeMake(self.anchor + *offset, *length);
-    } else if (length) {
-        node.range = HFRangeMake(self.anchor + self.position, *length);
+    HFTemplateNode *currentNode = self.currentNode;
+    HFTemplateNode *newNode = [[HFTemplateNode alloc] initWithLabel:label value:value];
+    if (length) {
+        if (offset) {
+            newNode.range = HFRangeMake(self.anchor + *offset, *length);
+        } else {
+            newNode.range = HFRangeMake(self.anchor + self.position, *length);
+        }
+        unsigned long long newloc = MIN(currentNode.range.location, newNode.range.location);
+        unsigned long long newlen = MAX(currentNode.range.location + currentNode.range.length, newNode.range.location + newNode.range.length) - newloc;
+        currentNode.range = HFRangeMake(newloc, newlen);
     } else if (offset) {
         HFASSERT(0); // invalid state
     }
-    [self.currentNode.children addObject:node];
+    [currentNode.children addObject:newNode];
 }
 
 - (BOOL)readBits:(NSString *)bits byteCount:(unsigned)numberOfBytes forLabel:(NSString *)label result:(uint64 *)result error:(NSString **)error {


### PR DESCRIPTION
When using the `entry` command with a <code><i>len</i></code> argument to add a node with a specified range, extend the range of the parent node to include the child node. (So it is reflected in the selected/highlighted range in the file when the entry is selected) Proposed as a way to 
Fixes #242 .