### PR TITLE
Fixes the unwanted release of DiffRangeWindowController.

### DIFF
--- a/app/sources/AppDelegate.h
+++ b/app/sources/AppDelegate.h
@@ -9,6 +9,7 @@
 
 @class ChooseStringEncodingWindowController;
 @class CLIController;
+@class DiffRangeWindowController;
 
 @interface AppDelegate : NSObject {
     IBOutlet NSMenuItem *extendForwardsItem, *extendBackwardsItem;
@@ -22,6 +23,7 @@
     IBOutlet ChooseStringEncodingWindowController *chooseStringEncoding;
     IBOutlet NSMenuItem *byteGroupingMenuItem;
     IBOutlet CLIController *cliController; // unused, prevents leak
+    IBOutlet DiffRangeWindowController *diffRangeWindowController;
 }
 
 - (IBAction)diffFrontDocuments:(id)sender;

--- a/app/sources/AppDelegate.m
+++ b/app/sources/AppDelegate.m
@@ -268,8 +268,8 @@ static NSComparisonResult compareFontDisplayNames(NSFont *a, NSFont *b, void *un
 
 - (IBAction)diffFrontDocumentsByRange:(id)sender {
     USE(sender);
-    DiffRangeWindowController* range = [[DiffRangeWindowController alloc] initWithWindowNibName:@"DiffRangeDialog"];
-    [range showWindow:self];
+    diffRangeWindowController = [[DiffRangeWindowController alloc] initWithWindowNibName:@"DiffRangeDialog"];
+    [diffRangeWindowController showWindow:self];
 }
 
 - (void)menuNeedsUpdate:(NSMenu *)menu {


### PR DESCRIPTION
Hello,
This pull request fixes the sudden release of `DiffRangeWindowController`. Indeed at the end of the `diffFrontDocumentsByRange` function, the controller is released (but not the window as it appeared). The consequences are that the window actions no longer work. To fix the problem, I just added a variable in `AppDelegate` that holds the controller.