### PR TITLE
Add check before editing when DataInspectorRepresentor value is double clicked

### DIFF
--- a/app/sources/DataInspectorRepresenter.m
+++ b/app/sources/DataInspectorRepresenter.m
@@ -289,7 +289,7 @@ NSString * const DataInspectorDidDeleteAllRows = @"DataInspectorDidDeleteAllRows
 - (IBAction)doubleClickedTable:(id)sender {
     USE(sender);
     NSInteger column = [table clickedColumn], row = [table clickedRow];
-    if (column >= 0 && row >= 0 && [[[table tableColumns][column] identifier] isEqual:kInspectorValueColumnIdentifier]) {
+    if (self.controller.editable && column >= 0 && row >= 0 && [[[table tableColumns][column] identifier] isEqual:kInspectorValueColumnIdentifier]) {
         BOOL isError;
         [self valueFromInspector:inspectors[row] isError:&isError];
         if (! isError) {


### PR DESCRIPTION
I think the logic at a higher level should be reworked but for the moment, this is a quick stopgap measure for preventing the most obvious discrepancies (namely files being edited & overwritten in Read-Only mode on the release builds.) Quick and dirty but fixes #243 .