### PR TITLE
Fix leak of extraArgs array allocated by Tcl_ParseArgsObjv

### DIFF
--- a/app/sources/HFTclTemplateController.m
+++ b/app/sources/HFTclTemplateController.m
@@ -612,15 +612,20 @@ DEFINE_COMMAND(uint64_bits)
             const char *arg = Tcl_GetStringFromObj(extraArgs[i], NULL);
             if (arg && arg[0] == '-') {
                 Tcl_SetObjResult(_interp, Tcl_ObjPrintf("Unknown option %s", arg));
+                ckfree((char *)extraArgs);
                 return TCL_ERROR;
             }
         }
         if (objc > 2) {
             const char *usage = hexSwitchAllowed ? "[-hex] [label]" : "[label";
             Tcl_WrongNumArgs(_interp, 0, objv, usage);
+            ckfree((char *)extraArgs);
             return TCL_ERROR;
         }
         label = [NSString stringWithUTF8String:Tcl_GetStringFromObj(extraArgs[1], NULL)];
+    }
+    if (objc > 0) {
+        ckfree((char *)extraArgs);
     }
     switch (command) {
         case command_uint64: {


### PR DESCRIPTION
From https://www.tcl.tk/man/tcl8.6/TclLib/ParseArgs.htm about remObjv:
Pointer to a variable that will hold the array of unprocessed arguments.
Should be NULL if no return of unprocessed arguments is required. If objcPtr
is updated to a non-zero value, the array returned through this must be
deallocated using ckfree.

Not sure why ckfree takes a char* as argument, but we need to cast
to make the compiler happy. Seems to be what other do too.