### PR TITLE
Format float and double with enough digits to not lose any precsion

### DIFF
--- a/app/sources/DataInspector.m
+++ b/app/sources/DataInspector.m
@@ -269,7 +269,7 @@ static NSString *floatingPointDescription(const unsigned char *bytes, NSUInteger
             _Static_assert(sizeof temp.f == sizeof temp.i, "sizeof(float) is not 4!");
             temp.i = *(const uint32_t *)bytes;
             if (endianness != eNativeEndianness) temp.i = (uint32_t)reverse(temp.i, sizeof(float));
-            return [NSString stringWithFormat:@"%.15g", temp.f];
+            return [NSString stringWithFormat:@"%.*g", FLT_DECIMAL_DIG, temp.f];
         }
         case sizeof(uint64_t):
         {
@@ -280,7 +280,7 @@ static NSString *floatingPointDescription(const unsigned char *bytes, NSUInteger
             _Static_assert(sizeof temp.f == sizeof temp.i, "sizeof(double) is not 8!");
             temp.i = *(const uint64_t *)bytes;
             if (endianness != eNativeEndianness) temp.i = reverse(temp.i, sizeof(double));
-            return [NSString stringWithFormat:@"%.15g", temp.f];
+            return [NSString stringWithFormat:@"%.*g", DBL_DECIMAL_DIG, temp.f];
         }
         case 10:
         {

--- a/app/sources/HFTemplateController.m
+++ b/app/sources/HFTemplateController.m
@@ -325,7 +325,7 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
     }
     *value = val.f;
     if (label) {
-        [self addNodeWithLabel:label value:[NSString stringWithFormat:@"%f", val.f] size:sizeof(val)];
+        [self addNodeWithLabel:label value:[NSString stringWithFormat:@"%.*g", FLT_DECIMAL_DIG, val.f] size:sizeof(val)];
     }
     return YES;
 }
@@ -345,7 +345,7 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
     }
     *value = val.f;
     if (label) {
-        [self addNodeWithLabel:label value:[NSString stringWithFormat:@"%f", val.f] size:sizeof(val)];
+        [self addNodeWithLabel:label value:[NSString stringWithFormat:@"%.*g", DBL_DECIMAL_DIG, val.f] size:sizeof(val)];
     }
     return YES;
 }


### PR DESCRIPTION
Template float/double used %f which default to 6 digits.
Data inspector used unnecessary precsion that might be confusing.

Maybe something similar should be done for 16, 80 and 128 bit floats.