### PR TITLE
Add a compare: method to HFStringEncoding.

### DIFF
--- a/framework/sources/HFStringEncoding.h
+++ b/framework/sources/HFStringEncoding.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)stringFromBytes:(const unsigned char *)bytes length:(NSUInteger)length;
 - (nullable NSData *)dataFromString:(NSString *)string;
 
--(NSComparisonResult)compare: (HFStringEncoding *)other;
+- (NSComparisonResult)compare:(HFStringEncoding *)other;
 
 @end
 

--- a/framework/sources/HFStringEncoding.h
+++ b/framework/sources/HFStringEncoding.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)stringFromBytes:(const unsigned char *)bytes length:(NSUInteger)length;
 - (nullable NSData *)dataFromString:(NSString *)string;
 
+-(NSComparisonResult)compare: (HFStringEncoding *)other;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/framework/sources/HFStringEncoding.m
+++ b/framework/sources/HFStringEncoding.m
@@ -32,7 +32,7 @@
     @throw [NSException exceptionWithName:NSGenericException reason:@"Unimplemented" userInfo:nil];
 }
 
--(NSComparisonResult)compare: (HFStringEncoding *)other {
+- (NSComparisonResult)compare:(HFStringEncoding *)other {
     return [self.name compare: other.name];
 }
 

--- a/framework/sources/HFStringEncoding.m
+++ b/framework/sources/HFStringEncoding.m
@@ -33,7 +33,7 @@
 }
 
 - (NSComparisonResult)compare:(HFStringEncoding *)other {
-    return [self.name compare: other.name];
+    return [self.name compare:other.name];
 }
 
 @end

--- a/framework/sources/HFStringEncoding.m
+++ b/framework/sources/HFStringEncoding.m
@@ -32,4 +32,8 @@
     @throw [NSException exceptionWithName:NSGenericException reason:@"Unimplemented" userInfo:nil];
 }
 
+-(NSComparisonResult)compare: (HFStringEncoding *)other {
+    return [self.name compare: other.name];
+}
+
 @end


### PR DESCRIPTION
This fixes issue #275 where `[customEncodings sortedArrayUsingSelector:@selector(compare:)];` fails due to the lack of a `compare:` method.  It could be handled in `HFCustomEncoding` but I figured it might be more useful moving it up the abstract base.

https://github.com/ridiculousfish/HexFiend/blob/b86a0d28e4b792b01dd5b806cd4cb684d8a34d40/app/sources/AppDelegate.m#L122-L129