### PR TITLE
Add explicit imports and forward declarations

### DIFF
--- a/app/sources/DataInspector.h
+++ b/app/sources/DataInspector.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class HFController;
+
 /* The largest number of bytes that any inspector type can edit */
 #define MAX_EDITABLE_BYTE_COUNT 128
 

--- a/app/sources/DataInspectorScrollView.m
+++ b/app/sources/DataInspectorScrollView.m
@@ -7,6 +7,8 @@
 
 #import "DataInspectorScrollView.h"
 
+#import <HexFiend/HFFunctions.h>
+
 @implementation DataInspectorScrollView
 
 - (void)drawDividerWithClip:(NSRect)clipRect {

--- a/framework/sources/HFController.h
+++ b/framework/sources/HFController.h
@@ -5,7 +5,11 @@
 //  Copyright 2007 ridiculous_fish. All rights reserved.
 //
 
+#import <HexFiend/HFTypes.h>
+
 NS_ASSUME_NONNULL_BEGIN
+
+@class NSEvent;
 
 /*! @header HFController
     @abstract The HFController.h header contains the HFController class, which is a central class in Hex Fiend. 

--- a/framework/sources/HFFunctions.h
+++ b/framework/sources/HFFunctions.h
@@ -5,6 +5,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if !TARGET_OS_IPHONE
+@class NSView;
+@class NSColor;
+#else
+@class UIColor;
+#endif
+
 #define HFDEFAULT_FONT (@"Monaco")
 #define HFDEFAULT_FONTSIZE ((CGFloat)10.)
 

--- a/framework/sources/HFProgressTracker.h
+++ b/framework/sources/HFProgressTracker.h
@@ -8,6 +8,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class NSProgressIndicator;
+
 /*!
 @class HFProgressTracker
 @brief A class that helps handle progress indication and cancellation for long running threaded operations.

--- a/framework/sources/HFRepresenter.h
+++ b/framework/sources/HFRepresenter.h
@@ -7,6 +7,8 @@
 
 #import <HexFiend/HFController.h>
 
+@class NSView;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /*! @class HFRepresenter

--- a/framework/sources/HFTextField.h
+++ b/framework/sources/HFTextField.h
@@ -6,6 +6,7 @@
 //
 
 #import <HexFiend/HFStringEncoding.h>
+#import <AppKit/AppKit.h>
 
 @class HFLayoutRepresenter, HFRepresenter, HFController, HFHexTextRepresenter, HFStringEncodingTextRepresenter;
 


### PR DESCRIPTION
HexFiend has some implicit including of frameworks and headers via its precompiled header.

The last time I updated HexFiend framework (and a couple other sources I use) in my project, I noted these were the minimum changes I needed to make for my project to compile. There might be a better solution in removing the precompiled headers in HexFiend although this is a short term fix that worked for me.