### PR TITLE
Fix byte theme color handling

### DIFF
--- a/app/sources/HFByteTheme.swift
+++ b/app/sources/HFByteTheme.swift
@@ -10,8 +10,8 @@ import Foundation
 
 private extension NSColor {
     func toRGB() -> NSColor {
-        guard let rgb = usingType(.componentBased) else {
-            fatalError("Can't convert color to calibratedRGB")
+        guard let rgb = usingColorSpace(.sRGB) else {
+            fatalError("Can't convert color to sRGB")
         }
         return rgb
     }
@@ -64,8 +64,8 @@ extension HFByteTheme {
     
     private static func colorTableFromDict(_ dict: NSDictionary) -> [HFByteThemeColor] {
         var table = [HFByteThemeColor](repeating: .init(), count: 256)
-        var custom: [[String: String]] = []
-        if let customDict = dict["custom"] as? [[String: String]] {
+        var custom: [[String: Any]] = []
+        if let customDict = dict["custom"] as? [[String: Any]] {
             custom = customDict
         }
     mainLoop: for b in 0..<table.count {


### PR DESCRIPTION
Two latent bugs caused byte themes to silently fail to load:

1. `toRGB()` used `usingType(.componentBased)`, which leaves named gray, black, white, and clear in Generic Gray Gamma 2.2. `getRed:green:blue:alpha:` then raises `NSInvalidArgumentException`, aborting `loadByteThemes`. Switched to `usingColorSpace(.sRGB)`.
2. `custom` predicates were cast as `[[String: String]]`, dropping the array if any color used a JSON5 hex literal (parsed as `UInt`). Widened to `[[String: Any]]`; `valueToColor` already accepts `Any`.