### PR TITLE
Fix Swift 6 concurrency error in hexf launchApp

### DIFF
--- a/hexf/hexf.swift
+++ b/hexf/hexf.swift
@@ -37,7 +37,7 @@ private struct Controller {
         if #available(macOS 10.15, *) {
             let config = NSWorkspace.OpenConfiguration()
             config.arguments = args
-            var openError: Error?
+            nonisolated(unsafe) var openError: Error?
             let semaphore = DispatchSemaphore(value: 0)
             NSWorkspace.shared.openApplication(at: url, configuration: config) { _, error in
                 openError = error


### PR DESCRIPTION
`NSWorkspace.openApplication`'s completion handler is `@Sendable`, so mutating `openError` from inside it is a Swift 6 strict concurrency error. The semaphore already serializes access, so marking the local `nonisolated(unsafe)` is the minimal fix.